### PR TITLE
feat: add router integrations

### DIFF
--- a/framework/components/AButton/AButton.js
+++ b/framework/components/AButton/AButton.js
@@ -8,6 +8,7 @@ const AButton = forwardRef(
     {
       children,
       className: propsClassName,
+      component,
       disabled,
       href,
       icon,
@@ -67,6 +68,10 @@ const AButton = forwardRef(
         props.tabIndex = 0;
       }
     } else {
+      if (component) {
+        TagName = component;
+      }
+
       props.disabled = disabled;
       props.type = type;
     }
@@ -81,9 +86,9 @@ AButton.defaultProps = {
 
 AButton.propTypes = {
   /**
-   * A class name to append to the component.
+   * Sets the base component. Useful for integrating with routers.
    */
-  className: PropTypes.string,
+  component: PropTypes.elementType,
   /**
    * Toggles the `disabled` state.
    */

--- a/framework/components/AButton/AButton.stories.mdx
+++ b/framework/components/AButton/AButton.stories.mdx
@@ -242,6 +242,14 @@ If the `href` property is used, the component will render as an HTML anchor.
   </AApp>
 </Preview>
 
+## Router Integrations
+
+Set the `component` property to your router's link type, for example:
+
+```
+// With react-router:
+<AButton component={RouterLink} to="/">Button 1</AButton>
+```
 
 ## Animations
 

--- a/framework/components/ADropdown/ADropdown.stories.mdx
+++ b/framework/components/ADropdown/ADropdown.stories.mdx
@@ -106,6 +106,15 @@ The `ADropdownMenuItem` component inherits passed props.
   </Story>
 </Preview>
 
+## Router Integrations
+
+On `ADropdownMenuItem`, set the `component` property to your router's link type, for example:
+
+```
+// With react-router:
+<ADropdownMenuItem component={RouterLink} to="/">Menu Item 1</ADropdownMenuItem>
+```
+
 ## Accessibility Notes
 
 By default, `ADropdownMenu` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [menu](https://www.w3.org/TR/wai-aria/#menu).

--- a/framework/components/ADropdown/ADropdownMenuItem.js
+++ b/framework/components/ADropdown/ADropdownMenuItem.js
@@ -9,6 +9,7 @@ const ADropdownMenuItem = forwardRef(
     {
       children,
       className: propsClassName,
+      component,
       href,
       onClick,
       onKeyDown,
@@ -50,8 +51,12 @@ const ADropdownMenuItem = forwardRef(
       props.target = target;
     }
 
-    if (href || onClick) {
+    if (href || onClick || component) {
       props.tabIndex = 0;
+    }
+
+    if (component) {
+      TagName = component;
     }
 
     return <TagName {...props}>{children}</TagName>;
@@ -59,6 +64,10 @@ const ADropdownMenuItem = forwardRef(
 );
 
 ADropdownMenuItem.propTypes = {
+  /**
+   * Sets the base component. Useful for integrating with routers.
+   */
+  component: PropTypes.elementType,
   /**
    * If specified, the component will render as an HTML link.
    */

--- a/framework/components/ATabs/ATab.js
+++ b/framework/components/ATabs/ATab.js
@@ -12,6 +12,7 @@ const ATab = forwardRef(
     {
       className: propsClassName,
       children,
+      component,
       href,
       onClick,
       onKeyDown,
@@ -72,13 +73,19 @@ const ATab = forwardRef(
       props.target = target;
     }
 
+    if (component) {
+      TagName = component;
+    }
+
     return <TagName {...props}>{children}</TagName>;
   }
 );
 
-ATab.contextType = ATabContext;
-
 ATab.propTypes = {
+  /**
+   * Sets the base component. Useful for integrating with routers.
+   */
+  component: PropTypes.elementType,
   /**
    * If specified, the component will render as an HTML link.
    */

--- a/framework/components/ATabs/ATabs.stories.mdx
+++ b/framework/components/ATabs/ATabs.stories.mdx
@@ -134,6 +134,15 @@ Tabs will render in the DOM as anchor tags if the `href` property is defined.
   </Story>
 </Preview>
 
+## Router Integrations
+
+On `ATab`, set the `component` property to your router's link type, for example:
+
+```
+// With react-router:
+<ATab component={RouterLink} to="/">Tab 1</ATab>
+```
+
 ## Accessibility Notes
 
 By default, `ATabGroup` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [tabslist](https://www.w3.org/TR/wai-aria/#tabslist).

--- a/framework/components/ATag/ATag.js
+++ b/framework/components/ATag/ATag.js
@@ -1,3 +1,4 @@
+import PropTypes from "prop-types";
 import React, {forwardRef} from "react";
 
 import "./ATag.scss";
@@ -8,6 +9,7 @@ const ATag = forwardRef(
     {
       children,
       className: propsClassName,
+      component,
       href,
       onClick,
       onKeyDown,
@@ -52,12 +54,31 @@ const ATag = forwardRef(
       props.role = "button";
     }
 
-    if (href || onClick) {
+    if (href || onClick || component) {
       props.tabIndex = 0;
+    }
+
+    if (component) {
+      TagName = component;
     }
 
     return <TagName {...props}>{children}</TagName>;
   }
 );
+
+ATag.propTypes = {
+  /**
+   * Sets the base component. Useful for integrating with routers.
+   */
+  component: PropTypes.elementType,
+  /**
+   * If specified, the component will render as an HTML link.
+   */
+  href: PropTypes.string,
+  /**
+   * If the `href` property is defined, the target can be set (ex: `_blank`, `_self`, `_parent`, `_top`)
+   */
+  target: PropTypes.string
+};
 
 export default ATag;

--- a/framework/components/ATag/ATag.stories.mdx
+++ b/framework/components/ATag/ATag.stories.mdx
@@ -112,6 +112,15 @@ The `ATag` component inherits passed props.
   </Story>
 </Preview>
 
+## Router Integrations
+
+Set the `component` property to your router's link type, for example:
+
+```
+// With react-router:
+<ATag component={RouterLink} to="/">Tag 1</ATag>
+```
+
 ## Accessibility Notes
 
 The `ATag` `click` event handler is triggered both by the `click` event and by the `keyDown` event for the `Enter` key.


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are represented in storybook
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

Closes #45 

**What is the current behavior?** <!--(You can also link to an open issue here)-->

There are no router integrations.

**What is the new behavior (if this is a feature change)?**

Link-like components (`ATab`, `ATag`, `ADropdownMenuItem`, `AButton`) have a new property that allows them to use router components as their base.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No.
