### PR TITLE
Pass value and inputProps to text area element

### DIFF
--- a/.storybook/changelog.stories.mdx
+++ b/.storybook/changelog.stories.mdx
@@ -8,6 +8,7 @@ import {Meta} from "@storybook/addon-docs/blocks";
 
 - Set default color for checkbox as the raw value of cisco-blue instead of using the helper class only available when wrapped with `AApp`.
 - Fixed an issue where `ADropdown` activators weren't focusable.
+- Fixed issue setting value to `ATextarea`.
 
 Added the following components:
 

--- a/framework/components/ATextInput/ATextInput.js
+++ b/framework/components/ATextInput/ATextInput.js
@@ -14,7 +14,6 @@ const ATextInput = forwardRef(
       autoComplete,
       className: propsClassName,
       disabled,
-      inputRef,
       label,
       name,
       onBlur,
@@ -109,7 +108,6 @@ const ATextInput = forwardRef(
         )}
         {prependIcon && <AIcon {...prependProps}>{prependIcon}</AIcon>}
         <input
-          ref={inputRef}
           autoComplete={autoComplete}
           className={inputClassName}
           disabled={disabled}
@@ -149,13 +147,6 @@ ATextInput.propTypes = {
    * Toggles the `disabled` state.
    */
   disabled: PropTypes.bool,
-  /**
-   * React ref for the input element
-   */
-  inputRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({current: PropTypes.any})
-  ]),
   /**
    * Sets the input label text.
    */

--- a/framework/components/ATextarea/ATextarea.js
+++ b/framework/components/ATextarea/ATextarea.js
@@ -10,7 +10,6 @@ const ATextarea = forwardRef(
     {
       className: propsClassName,
       disabled,
-      inputRef,
       inputProps,
       label,
       placeholder,
@@ -44,7 +43,6 @@ const ATextarea = forwardRef(
           </label>
         )}
         <textarea
-          ref={inputRef}
           id={`a-textarea__field_${textareaId}`}
           disabled={disabled}
           placeholder={placeholder}
@@ -64,10 +62,6 @@ ATextarea.defaultProps = {
 };
 
 ATextarea.propTypes = {
-  inputRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({current: PropTypes.any})
-  ]),
   /**
    * Sets the textarea label text.
    */

--- a/framework/components/ATextarea/ATextarea.stories.mdx
+++ b/framework/components/ATextarea/ATextarea.stories.mdx
@@ -25,6 +25,9 @@ import {ATextarea} from "@cisco-ats/atomic-react";
       <div className="mb-4">
         <ATextarea label="Label" placeholder="Normal" />
       </div>
+       <div className="mb-4">
+        <ATextarea label="Label" placeholder="Normal with value" value="Text value" />
+      </div>
       <div className="mb-4">
         <ATextarea label="Label" placeholder="Disabled" disabled />
       </div>


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
<!--A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]-->

Need to be able to reference the `<input>` element for a custom inline edit in the Ribbon.

**Describe the solution you'd like**
<!--A clear and concise description of what you want to happen.-->

Add an `inputRef` prop to ATextInput and ATextarea that attaches a React ref to the html element.

**Describe alternatives you've considered**
<!--A clear and concise description of any alternative solutions or features you've considered.-->

N/A

