### PR TITLE
Fix padding in ATextInput

### DIFF
--- a/framework/styles/utilities/variables.scss
+++ b/framework/styles/utilities/variables.scss
@@ -216,7 +216,7 @@ $btn--icon-border-radius: 30px;
 // Shared input styles
 // -----------------------------------------------------------------------------
 $input-border-color--active: map-get($cisco-blue, "burnt-1");
-$input-padding: 4px 20px 2px 6px;
+$input-padding: 2px 20px 2px 6px;
 $input-transition: border-color $transition-duration--extra-fast
     $transition-timing-function--standard,
   box-shadow $transition-duration--extra-fast


### PR DESCRIPTION
**Describe the bug**
<!--A clear and concise description of what the bug is.-->

The padding is uneven, 4px top, 2px bottom, making the text look off-middle vertically.

**To Reproduce**
Steps to reproduce the behavior:
<!--
1. Go to '...'
2. Click on '....'
3. Scroll down to '....'
4. See error
-->

**Expected behavior**
<!--A clear and concise description of what you expected to happen.-->

Text should be in the center of the input, vertically

**Screenshots**
<!--If applicable, add screenshots to help explain your problem.-->

![Screen Shot 2020-04-27 at 2 44 49 PM](https://user-images.githubusercontent.com/23561587/80413818-ac461480-8895-11ea-973a-24756f1fd21b.png)


**Environment (please complete the following information):**
 - All browsers

**Additional context**
<!--Add any other context about the problem here.-->
