### PR TITLE
feat: add vertical-align helper and adjust a-simple-table

### DIFF
--- a/.storybook/changelog.stories.mdx
+++ b/.storybook/changelog.stories.mdx
@@ -9,6 +9,8 @@ import {Meta} from "@storybook/addon-docs/blocks";
 - Modified `AMenuBase` to position the menu within the viewable area if opened near an edge.
 - Added `component` prop to `APanel`, allowing specification of the base component.
 - Fixed an issue where `ASelect` would crash if object items were used and no default was set.
+- Adjusted `ASimpleTable` styles to ease ability to override `vertical-align`.
+- Added a helper class for `vertical-align`.
 
 Added the following components:
 

--- a/framework/components/AApp/AApp.stories.mdx
+++ b/framework/components/AApp/AApp.stories.mdx
@@ -705,6 +705,10 @@ Media queries are set for the following breakpoints:
   - is responsive (not print)
   - values: `left`, `right`, `center`, `justify`, `start`, `end`
   - examples: `text-center text-sm-left`
+- `vertical-align`
+  - not responsive
+  - values: `top`, `center`, `baseline`, `bottom`
+  - examples: `vertical-align-center`
 - `white-space`
   - prefix: `text`
   - is not responsive

--- a/framework/components/AApp/base/helpers.scss
+++ b/framework/components/AApp/base/helpers.scss
@@ -264,6 +264,15 @@ $helpers: (
     class: text,
     values: left right center justify start end
   ),
+  "vertical-align": (
+    property: vertical-align,
+    values: (
+      top: top,
+      center: middle,
+      baseline: baseline,
+      bottom: bottom
+    )
+  ),
   "white-space": (
     property: white-space,
     class: text,

--- a/framework/components/ASimpleTable/ASimpleTable.scss
+++ b/framework/components/ASimpleTable/ASimpleTable.scss
@@ -66,8 +66,13 @@ $table-cell-tight-padding-top-bottom: (
     padding-top: $table__total--padding-top;
   }
 
+  tbody {
+    vertical-align: top;
+  }
+
   tr {
     height: $table-row-height;
+    vertical-align: inherit;
   }
 
   th,
@@ -75,6 +80,7 @@ $table-cell-tight-padding-top-bottom: (
     padding-left: $table-cell-padding-left-right;
     padding-right: $table-cell-padding-left-right;
     min-width: $table-cell-min-width;
+    vertical-align: inherit;
   }
 
   th {
@@ -95,7 +101,6 @@ $table-cell-tight-padding-top-bottom: (
     border-style: solid;
     padding-top: $table-cell-padding-top-bottom;
     padding-bottom: $table-cell-padding-top-bottom;
-    vertical-align: top;
     word-break: break-word;
     &:not(:first-child) {
       border-left: none;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are documented in component docs and changelog
- [X] The ESLint plugin has been updated if a new component is added
- [X] Test have been added or modified, if appropriate
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

Closes #154 

**What is the current behavior?** <!--(You can also link to an open issue here)-->

No vertical-align class helper, `ASimpleTable` has `td` styled specifically to be `vertical-align: top`.

**What is the new behavior (if this is a feature change)?**

Added a `vertical-align` class helper, adjusted `ASimpleTable` to have `tr`, `td`, `th` inherit `vertical-align`, and assigned `vertical-align: top` to `tbody`.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No
