### PR TITLE
fix: trigger menu close-on-click

### DIFF
--- a/.storybook/changelog.stories.mdx
+++ b/.storybook/changelog.stories.mdx
@@ -4,8 +4,15 @@ import {Meta} from "@storybook/addon-docs/blocks";
 
 # Changelog
 
+## 2.1.1
+
+- Fixed an issue where `closeOnClick` was not working with `AMenu`. Fixed test.
+- Reduced the `z-index` of `AHeader` to appear under menus.
+- Fixed an issue with `ADataTable` where `undefined` would sneak into the class list of headers when `className` is `undefined`.
+
 ## 2.1.0
 
+- Changed the `module` entry of `package.json` to point to the `lib` build.
 - Modified `AMenuBase` to position the menu within the viewable area if opened near an edge.
 - Added `component` prop to `APanel`, allowing specification of the base component.
 - Fixed an issue where `ASelect` would crash if object items were used and no default was set.

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -32,7 +32,7 @@ const ADataTable = forwardRef(
                   const headerProps = {
                     className: `a-data-table__header ${
                       x.sortable ? "a-data-table__header--sortable" : ""
-                    } ${x.className}`,
+                    } ${x.className || ""}`,
                     role: "columnheader",
                     scope: "col",
                     "aria-label": x.name

--- a/framework/components/AHeader/AHeader.scss
+++ b/framework/components/AHeader/AHeader.scss
@@ -40,7 +40,7 @@ $header__logo-margin: 0 20px 0 0;
   min-width: $header-min-width;
   align-items: center;
   box-shadow: $default-box-shadow;
-  z-index: 1030;
+  z-index: 7;
   overflow: visible;
   &__logo {
     display: block;

--- a/framework/components/AMenu/AMenu.js
+++ b/framework/components/AMenu/AMenu.js
@@ -102,7 +102,7 @@ const AMenu = forwardRef(
         className={className}
         hoverable={hoverable}
         onClick={(e) => {
-          closeOnClick && closeHandler;
+          closeOnClick && closeHandler(e);
           onClick && onClick(e);
         }}
         onClose={onClose}

--- a/framework/components/AMenu/AMenu.spec.js
+++ b/framework/components/AMenu/AMenu.spec.js
@@ -6,6 +6,9 @@ context("AMenu", () => {
   });
 
   it("opens and closes appropriately", () => {
+    const stub = cy.stub();
+    cy.on("window:alert", stub);
+
     cy.get(".a-menu").should("not.be.visible");
     cy.get("#story--components-menus--usage-1 .a-button").eq(0).click();
     cy.get(".a-menu")
@@ -14,13 +17,22 @@ context("AMenu", () => {
       .then(($el) => {
         Cypress.dom.isFocused($el);
       })
-      .click("top")
       .type("{esc}");
     cy.get(".a-menu").should("not.be.visible");
     cy.get("#story--components-menus--usage-1 .a-button")
       .eq(0)
       .then(($el) => {
         Cypress.dom.isFocused($el);
+      });
+
+    cy.get("#story--components-menus--usage-1 .a-button").eq(0).click();
+    cy.get(".a-menu")
+      .eq(0)
+      .find(".a-list-item")
+      .first()
+      .click()
+      .then(() => {
+        cy.get(".a-menu").should("not.be.visible");
       });
   });
 
@@ -47,7 +59,6 @@ context("AMenu", () => {
       .then(($el) => {
         Cypress.dom.isFocused($el);
       })
-      .click("top")
       .type("{downArrow}")
       .find(".a-list-item[tabindex]")
       .first()
@@ -66,7 +77,6 @@ context("AMenu", () => {
       .then(($el) => {
         Cypress.dom.isFocused($el);
       })
-      .click("top")
       .type("{upArrow}")
       .find(".a-list-item[tabindex]")
       .last()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "main": "index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are documented in component docs and changelog
- [X] The ESLint plugin has been updated if a new component is added
- [X] Test have been added or modified, if appropriate
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

This PR:

- Fixes an issue where `closeOnClick` was not working with `AMenu`. Fixes test.
- Reduces the `z-index` of `AHeader` to appear under menus.
- Fixes an issue with `ADataTable` where `undefined` would sneak into the class list of headers when `className` is `undefined`.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No.
