### PR TITLE
fix: transform button group context reference

### DIFF
--- a/.storybook/changelog.stories.mdx
+++ b/.storybook/changelog.stories.mdx
@@ -4,6 +4,14 @@ import {Meta} from "@storybook/addon-docs/blocks";
 
 # Changelog
 
+## 2.2.5
+
+- Fix reference from `AButton` to `AButtonGroupContext` for `lib` build
+
+## 2.2.4
+
+- Fix babel preset generation on build server
+
 ## 2.2.2
 
 - Removed absolute positioning on the `ADialog` backdrop when active.

--- a/build/babel-transform-paths.js
+++ b/build/babel-transform-paths.js
@@ -6,11 +6,10 @@ module.exports = wrapListener(listener, "transform-paths");
 function listener(path, file) {
   if (!path.isLiteral()) return;
 
-  if (path.node.value === "./AAppContext") {
-    path.node.value = "../../../AAppContext";
-  }
-
-  if (path.node.value === "../AApp/AAppContext") {
+  if (
+    path.node.value === "./AAppContext" ||
+    path.node.value === "../AApp/AAppContext"
+  ) {
     path.node.value = "../../../AAppContext";
   }
 
@@ -22,7 +21,10 @@ function listener(path, file) {
     path.node.value = join("../../../AAccordionPanelContext");
   }
 
-  if (path.node.value === "./AButtonGroupContext") {
+  if (
+    path.node.value === "../AButtonGroup/AButtonGroupContext" ||
+    path.node.value === "./AButtonGroupContext"
+  ) {
     path.node.value = join("../../../AButtonGroupContext");
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "description": "",
   "main": "index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are documented in component docs and changelog
- [X] The ESLint plugin has been updated if a new component is added
- [X] Test have been added or modified, if appropriate
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

Closes #175 
The reference to `AButtonGroupContext` from `AButton` wasn't transformed properly in the `lib` build

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No
