### PR TITLE
fix(ASelect): add to comparator for selected item

### DIFF
--- a/.storybook/changelog.stories.mdx
+++ b/.storybook/changelog.stories.mdx
@@ -6,11 +6,13 @@ import {Meta} from "@storybook/addon-docs/blocks";
 
 ## 2.2.5
 
-- Fix reference from `AButton` to `AButtonGroupContext` for `lib` build
+- Fixed reference from `AButton` to `AButtonGroupContext` for `lib` build
+- Fixed reference from form fields to `AFormContext` for `lib` build
+- Fixed `ASelect` selected item changing after being initialized without a selected item.
 
 ## 2.2.4
 
-- Fix babel preset generation on build server
+- Fixed babel preset generation on build server
 
 ## 2.2.2
 

--- a/build/babel-transform-paths.js
+++ b/build/babel-transform-paths.js
@@ -28,6 +28,13 @@ function listener(path, file) {
     path.node.value = join("../../../AButtonGroupContext");
   }
 
+  if (
+    path.node.value === "../AForm/AFormContext" ||
+    path.node.value === "./AFormContext"
+  ) {
+    path.node.value = join("../../../AFormContext");
+  }
+
   if (path.node.value === "./ATabContext") {
     path.node.value = join("../../../ATabContext");
   }

--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -65,6 +65,10 @@ const ASelect = forwardRef(
       const newSelectedItem = items.find((x) => x[itemSelected]);
 
       if (
+        (!["string", "object"].includes(typeof originalSelectedItem) &&
+          ["string", "object"].includes(typeof newSelectedItem)) ||
+        (["string", "object"].includes(typeof originalSelectedItem) &&
+          !["string", "object"].includes(typeof newSelectedItem)) ||
         (typeof newSelectedItem === "string" &&
           typeof originalSelectedItem === "object") ||
         (typeof newSelectedItem === "object" &&


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are documented in component docs and changelog
- [X] The ESLint plugin has been updated if a new component is added
- [X] Test have been added or modified, if appropriate
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

Closes #177 

**What is the current behavior?** <!--(You can also link to an open issue here)-->

When the `ASelect` component is initializes without a selected value, the comparator is unable to determine if the selected value has changed.

**What is the new behavior (if this is a feature change)?**

A check was added so that non-string and non-objects are also compared against the new selected value.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No
