### PR TITLE
Chevron Direction Class for QA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,10 @@
 /useA*.js
 /_rollupPluginBabelHelpers*
 __diff_output__
+
+# Editor generated backup files #
+#################################
+*~
+*#
+#*
+.#*

--- a/framework/components/ATree/ATree.js
+++ b/framework/components/ATree/ATree.js
@@ -154,6 +154,8 @@ const ATree = forwardRef(
         nodeProps["aria-expanded"] = Boolean(item.expanded);
       }
 
+      const chevronDirection = item.expanded ? "chevron-down" : "chevron-right";
+
       return (
         <div {...nodeProps}>
           <div
@@ -168,11 +170,11 @@ const ATree = forwardRef(
               <AButton
                 tertiaryAlt
                 icon
-                className="a-tree__chevron"
+                className={"a-tree__chevron " + chevronDirection}
                 onClick={expandHandler(path)}
                 style={{color: "currentColor"}}>
-                <AIcon size={10}>
-                  {item.expanded ? "chevron-down" : "chevron-right"}
+                <AIcon size={10} className={chevronDirection}>
+                  {chevronDirection}
                 </AIcon>
               </AButton>
             )}


### PR DESCRIPTION
QA would like classes added to indicate the collapse/expand state of the the ATree buttons/chevrons.

Reference: https://github.com/threatgrid/GLaDOS/issues/649

