### PR TITLE
fix: maintain dialog child autofocus

### DIFF
--- a/.storybook/changelog.stories.mdx
+++ b/.storybook/changelog.stories.mdx
@@ -4,6 +4,10 @@ import {Meta} from "@storybook/addon-docs/blocks";
 
 # Changelog
 
+## 2.2.8
+
+- Fixed maintaining the autofocus of a child element of `ADialog` on `open`.
+
 ## 2.2.7
 
 - Added `sideEffects` to `package.json`, so `lib` build should be treeshake-able by bundlers.

--- a/framework/components/ADialog/ADialog.js
+++ b/framework/components/ADialog/ADialog.js
@@ -3,6 +3,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useRef
 } from "react";
 import ReactDOM from "react-dom";
@@ -27,7 +28,7 @@ const ADialog = forwardRef(
     },
     ref
   ) => {
-    useEffect(() => {
+    useLayoutEffect(() => {
       if (open) {
         launcherElement = document.activeElement;
       } else {
@@ -44,6 +45,7 @@ const ADialog = forwardRef(
       if (open) {
         combinedRef &&
           combinedRef.current &&
+          !combinedRef.current.contains(document.activeElement) &&
           combinedRef.current.focus({
             preventScroll: true
           });

--- a/framework/components/ADialog/ADialog.spec.js
+++ b/framework/components/ADialog/ADialog.spec.js
@@ -20,7 +20,23 @@ context("ADialog", () => {
         Cypress.dom.isFocused($el);
       })
       .click();
+    // the `isCovered` command doesn't allow follow-up commands, so need to clean up in next test
     cy.isCovered("#story--components-dialogs--usage-1 .a-button:nth-child(1)");
+  });
+
+  it("maintains auto-focused child", () => {
     cy.get(".a-app .a-dialog").eq(0).click("bottom");
+    cy.get("#story--components-dialogs--autofocus-1 .a-button").eq(0).click();
+    cy.get(".a-app .a-dialog .a-text-input__input")
+      .eq(0)
+      .then(($el) => {
+        Cypress.dom.isFocused($el);
+      });
+    cy.get(".a-app .a-dialog").eq(0).click("bottom");
+    cy.get("#story--components-dialogs--autofocus-1 .a-button")
+      .eq(0)
+      .then(($el) => {
+        Cypress.dom.isFocused($el);
+      });
   });
 });

--- a/framework/components/ADialog/ADialog.stories.mdx
+++ b/framework/components/ADialog/ADialog.stories.mdx
@@ -12,6 +12,7 @@ import {
   APanelBody,
   APanelFooter
 } from "../APanel";
+import ATextInput from "../ATextInput";
 import ADialog from "./ADialog";
 
 <Meta title="Components/Dialogs" component={ADialog} />
@@ -87,10 +88,49 @@ The `ADialog` component inherits passed props to the dialog content wrapper.
 
 <Props of={ADialog} />
 
+## Autofocused Child
+
+<Preview>
+  <Story name="autofocus-1">
+    <div>
+      <YourComponent>
+        {() => {
+          const [open1, setOpen1] = useState(false);
+          return (
+            <>
+              <AButton onClick={() => setOpen1(true)}>Open Dialog 1</AButton>
+              <ADialog onClickOutside={() => setOpen1(false)} open={open1}>
+                <APanel type="dialog">
+                  <APanelHeader>
+                    <APanelTitle>Feature: Panels</APanelTitle>
+                    <AButton onClick={() => setOpen1(false)} tertiaryAlt icon>
+                      <AIcon>close</AIcon>
+                    </AButton>
+                  </APanelHeader>
+                  <APanelBody>
+                    <p>
+                      When a child is auto-focused, the dialog ensures focus is
+                      maintained on that element.
+                    </p>
+                    <ATextInput label="Name" autoFocus />
+                  </APanelBody>
+                  <APanelFooter>
+                    <AButton>Submit</AButton>
+                  </APanelFooter>
+                </APanel>
+              </ADialog>
+            </>
+          );
+        }}
+      </YourComponent>
+    </div>
+  </Story>
+</Preview>
+
 ## Accessibility Notes
 
 `ADialog` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [document](https://www.w3.org/TR/wai-aria/#document). It is an industry standard to avoid using the role of [dialog](https://www.w3.org/TR/wai-aria/#dialog) due to the way screen readers treat content with the dialog role versus how dialogs are actually used in applications, specifically regarding text content and reading keys.
 
-When the `ADialog` is open, focus is set to the dialog content wrapper. When the `ADialog` is closed, focus is returned to the previously focused element.
+When the `ADialog` is open, focus is set to the dialog content wrapper unless a child element is focused. When the `ADialog` is closed, focus is returned to the previously focused element.
 
 The `onClickOutside` handler will also handle the `keydown` event for the `esc` key.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12237,9 +12237,9 @@
       "dev": true
     },
     "minipass": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
-      "integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+      "integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
       "dev": true,
       "requires": {
         "yallist": "^4.0.0"
@@ -12272,9 +12272,9 @@
       }
     },
     "minipass-pipeline": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.2.tgz",
-      "integrity": "sha512-3JS5A2DKhD2g0Gg8x3yamO0pj7YeKGwVlDS90pF++kxptwx/F+B//roxf9SqYil5tQo65bijy+dAuAFZmYOouA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "dev": true,
       "requires": {
         "minipass": "^3.0.0"
@@ -17253,22 +17253,34 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.5.tgz",
-      "integrity": "sha512-WlWksUoq+E4+JlJ+h+U+QUzXpcsMSSNXkDy9lBVkSqDn1w23Gg29L/ary9GeJVYCGiNJJX7LnVc4bwL1N3/g1w==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-2.3.8.tgz",
+      "integrity": "sha512-/fKw3R+hWyHfYx7Bv6oPqmk4HGQcrWLtV3X6ggvPuwPNHSnzvVV51z6OaaCOus4YLjutYGOz3pEpbhe6Up2s1w==",
       "dev": true,
       "requires": {
         "cacache": "^13.0.1",
-        "find-cache-dir": "^3.2.0",
-        "jest-worker": "^25.1.0",
-        "p-limit": "^2.2.2",
-        "schema-utils": "^2.6.4",
-        "serialize-javascript": "^2.1.2",
+        "find-cache-dir": "^3.3.1",
+        "jest-worker": "^25.4.0",
+        "p-limit": "^2.3.0",
+        "schema-utils": "^2.6.6",
+        "serialize-javascript": "^4.0.0",
         "source-map": "^0.6.1",
-        "terser": "^4.4.3",
+        "terser": "^4.6.12",
         "webpack-sources": "^1.4.3"
       },
       "dependencies": {
+        "ajv": {
+          "version": "6.12.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
         "cacache": {
           "version": "13.0.1",
           "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
@@ -17294,6 +17306,18 @@
             "ssri": "^7.0.0",
             "unique-filename": "^1.1.1"
           }
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
         },
         "find-cache-dir": {
           "version": "3.3.1",
@@ -17323,9 +17347,9 @@
           "dev": true
         },
         "jest-worker": {
-          "version": "25.1.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.1.0.tgz",
-          "integrity": "sha512-ZHhHtlxOWSxCoNOKHGbiLzXnl42ga9CxDr27H36Qn+15pQZd3R/F24jrmjDelw9j/iHUIWMWs08/u2QN50HHOg==",
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-25.5.0.tgz",
+          "integrity": "sha512-/dsSmUkIy5EBGfv/IjjqmFxrNAUpBERfGs1oHROyD7yxjG/w+t0GOJDX8O1k32ySmd7+a5IhnJU2qQFcJ4n1vw==",
           "dev": true,
           "requires": {
             "merge-stream": "^2.0.0",
@@ -17351,12 +17375,21 @@
           }
         },
         "make-dir": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-          "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
           "dev": true,
           "requires": {
             "semver": "^6.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
@@ -17393,12 +17426,13 @@
           }
         },
         "schema-utils": {
-          "version": "2.6.5",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.5.tgz",
-          "integrity": "sha512-5KXuwKziQrTVHh8j/Uxz+QUbxkaLW9X/86NBlx/gnKgtsZA2GIVMUn17qWhRFwF8jdYb3Dig5hRO/W5mZqy6SQ==",
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
           "dev": true,
           "requires": {
-            "ajv": "^6.12.0",
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
             "ajv-keywords": "^3.4.1"
           }
         },
@@ -17407,6 +17441,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
+        },
+        "serialize-javascript": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+          "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+          "dev": true,
+          "requires": {
+            "randombytes": "^2.1.0"
+          }
         },
         "source-map": {
           "version": "0.6.1",
@@ -17431,6 +17474,17 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
+          }
+        },
+        "terser": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+          "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
           }
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "description": "",
   "main": "index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are documented in component docs and changelog
- [X] The ESLint plugin has been updated if a new component is added
- [X] Test have been added or modified, if appropriate
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

When an `ADialog` is opened, it focuses itself for accessibility. This causes an issue if the dialog has an auto-focused child element. The changes here are to:

1. Check to see if the currently focused element is a child element before having the dialog focus itself.
2. If a child element is autofocused, the event occurred between the launcher element being triggered and the child element being focused, which throws off the return of focus when the dialog closes -- using `useLayoutEffect` solves this.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No
