### PR TITLE
fix: always validate on blur

### DIFF
--- a/.storybook/changelog.stories.mdx
+++ b/.storybook/changelog.stories.mdx
@@ -4,6 +4,10 @@ import {Meta} from "@storybook/addon-docs/blocks";
 
 # Changelog
 
+## 2.2.9
+
+- Fixed `validateOnBlur` to not disable validation on `blur` if not present.
+
 ## 2.2.8
 
 - Fixed maintaining the autofocus of a child element of `ADialog` on `open`.

--- a/build/generate-babel-preset.js
+++ b/build/generate-babel-preset.js
@@ -8,7 +8,6 @@ const files = glob.sync("./framework/components/**/index.js");
 const getComponents = (data) => {
   const components = [];
   let matches = data.match(/([\{,][\s]?|  )([\w]+)/g);
-  console.log(matches);
   components.push(...matches);
   return components.map((x) => {
     return x.replace("  ", "").replace(", ", "").replace("{", "");

--- a/framework/components/AAutocomplete/AAutocomplete.js
+++ b/framework/components/AAutocomplete/AAutocomplete.js
@@ -158,9 +158,7 @@ const AAutocomplete = forwardRef(
       id: `a-autocomplete_${autocompleteId}`,
       onBlur: (e) => {
         setIsFocused(false);
-        validateOnBlur &&
-          !dropdownMenuRef.current.contains(e.relatedTarget) &&
-          validate(value);
+        !dropdownMenuRef.current.contains(e.relatedTarget) && validate(value);
       },
       onChange: (e) => {
         setIsOpen(true);
@@ -333,7 +331,7 @@ AAutocomplete.propTypes = {
     })
   ),
   /**
-   * Sets the validation rules to evaluate on `blur` rather than on `change`.
+   * Delays validation until the `blur` event.
    */
   validateOnBlur: PropTypes.bool,
   /**

--- a/framework/components/AAutocomplete/AAutocomplete.spec.js
+++ b/framework/components/AAutocomplete/AAutocomplete.spec.js
@@ -142,6 +142,17 @@ context("AAutocomplete", () => {
       .type("{esc}");
   });
 
+  it("validates on blur", () => {
+    cy.get("#story--components-autocompletes--rules-2 .a-autocomplete__input")
+      .eq(0)
+      .tab()
+      .tab({shift: true})
+      .tab();
+    cy.get("#story--components-autocompletes--rules-2 .a-input-base__hint")
+      .eq(0)
+      .contains("Food Group is required");
+  });
+
   it("validates", () => {
     cy.get("#story--components-autocompletes--rules-1 .a-autocomplete__input")
       .eq(0)

--- a/framework/components/AAutocomplete/AAutocomplete.stories.mdx
+++ b/framework/components/AAutocomplete/AAutocomplete.stories.mdx
@@ -149,7 +149,7 @@ The `AAutocomplete` component inherits passed props.
 <Preview>
   <Story name="rules-1">
     <div style={{minHeight: 220, minWidth: 250, marginRight: 20}}>
-      <h3>Autocomplete with Validation</h3>
+      <h3>Autocomplete with Postponed Validation</h3>
       <YourComponent>
         {() => {
           const items = [
@@ -188,6 +188,52 @@ The `AAutocomplete` component inherits passed props.
                 setValue(e.target.value);
               }}
               validateOnBlur
+            />
+          );
+        }}
+      </YourComponent>
+    </div>
+  </Story>
+  <Story name="rules-2">
+    <div style={{minHeight: 220, minWidth: 250, marginRight: 20}}>
+      <h3>Autocomplete with Change Validation</h3>
+      <YourComponent>
+        {() => {
+          const items = [
+            "Bread, Cereal, Rice, and Pasta",
+            "Vegetables",
+            "Fruit",
+            "Milk, Yogurt, and Cheese",
+            "Meat, Poultry, Fish",
+            "Fats, Oils, and Sweets"
+          ];
+          const [value, setValue] = useState("");
+          const [filteredItems, setFilteredItems] = useState(items);
+          return (
+            <AAutocomplete
+              clearable
+              label="Food Group"
+              items={filteredItems}
+              placeholder="Pick a Food Group"
+              onSelected={(item) => {
+                setValue(item);
+              }}
+              required
+              rules={[
+                {
+                  test: (v) => /[A-Z]+/.test(v) || "Must have a capital letter",
+                  level: "warning"
+                }
+              ]}
+              value={value}
+              onChange={(e) => {
+                setFilteredItems(
+                  items.filter((x) =>
+                    x.toLowerCase().includes(e.target.value.toLowerCase())
+                  )
+                );
+                setValue(e.target.value);
+              }}
             />
           );
         }}

--- a/framework/components/ACombobox/ACombobox.js
+++ b/framework/components/ACombobox/ACombobox.js
@@ -158,9 +158,7 @@ const ACombobox = forwardRef(
       id: `a-combobox_${comboboxId}`,
       onBlur: (e) => {
         setIsFocused(false);
-        validateOnBlur &&
-          !dropdownMenuRef.current.contains(e.relatedTarget) &&
-          validate(value);
+        !dropdownMenuRef.current.contains(e.relatedTarget) && validate(value);
       },
       onChange: (e) => {
         setIsOpen(items.length || noDataContent);
@@ -325,7 +323,7 @@ ACombobox.propTypes = {
     })
   ),
   /**
-   * Sets the validation rules to evaluate on `blur` rather than on `change`.
+   * Delays validation until the `blur` event.
    */
   validateOnBlur: PropTypes.bool,
   /**

--- a/framework/components/ACombobox/ACombobox.spec.js
+++ b/framework/components/ACombobox/ACombobox.spec.js
@@ -129,6 +129,17 @@ context("ACombobox", () => {
       .type("{esc}");
   });
 
+  it("validates on blur", () => {
+    cy.get("#story--components-comboboxes--rules-2 .a-combobox__input")
+      .eq(0)
+      .tab()
+      .tab({shift: true})
+      .tab();
+    cy.get("#story--components-comboboxes--rules-2 .a-input-base__hint")
+      .eq(0)
+      .contains("Food Group is required");
+  });
+
   it("validates", () => {
     cy.get("#story--components-comboboxes--rules-1 .a-combobox__input")
       .eq(0)

--- a/framework/components/ACombobox/ACombobox.stories.mdx
+++ b/framework/components/ACombobox/ACombobox.stories.mdx
@@ -169,7 +169,7 @@ The `ACombobox` component inherits passed props.
 <Preview>
   <Story name="rules-1">
     <div style={{minHeight: 220, minWidth: 250, marginRight: 20}}>
-      <h3>Combobox with Validation</h3>
+      <h3>Combobox with Postponed Validation</h3>
       <YourComponent>
         {() => {
           const items = [
@@ -208,6 +208,52 @@ The `ACombobox` component inherits passed props.
                 setValue(e.target.value);
               }}
               validateOnBlur
+            />
+          );
+        }}
+      </YourComponent>
+    </div>
+  </Story>
+  <Story name="rules-2">
+    <div style={{minHeight: 220, minWidth: 250, marginRight: 20}}>
+      <h3>Combobox with Change Validation</h3>
+      <YourComponent>
+        {() => {
+          const items = [
+            "Bread, Cereal, Rice, and Pasta",
+            "Vegetables",
+            "Fruit",
+            "Milk, Yogurt, and Cheese",
+            "Meat, Poultry, Fish",
+            "Fats, Oils, and Sweets"
+          ];
+          const [value, setValue] = useState("");
+          const [filteredItems, setFilteredItems] = useState(items);
+          return (
+            <ACombobox
+              clearable
+              label="Food Group"
+              items={filteredItems}
+              placeholder="Pick a Food Group"
+              onSelected={(item) => {
+                setValue(item);
+              }}
+              required
+              rules={[
+                {
+                  test: (v) => /[A-Z]+/.test(v) || "Must have a capital letter",
+                  level: "warning"
+                }
+              ]}
+              value={value}
+              onChange={(e) => {
+                setFilteredItems(
+                  items.filter((x) =>
+                    x.toLowerCase().includes(e.target.value.toLowerCase())
+                  )
+                );
+                setValue(e.target.value);
+              }}
             />
           );
         }}

--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -216,8 +216,7 @@ const ASelect = forwardRef(
 
       selectionProps.onBlur = (e) => {
         setIsFocused(false);
-        validateOnBlur &&
-          !dropdownMenuRef.current.contains(e.relatedTarget) &&
+        !dropdownMenuRef.current.contains(e.relatedTarget) &&
           validate(selectedItem);
       };
 
@@ -426,7 +425,7 @@ ASelect.propTypes = {
     })
   ),
   /**
-   * Sets the validation rules to evaluate on `blur` rather than on `change`.
+   * Delays validation until the `blur` event.
    */
   validateOnBlur: PropTypes.bool,
   /**

--- a/framework/components/ASelect/ASelect.spec.js
+++ b/framework/components/ASelect/ASelect.spec.js
@@ -140,6 +140,17 @@ context("ASelect", () => {
       .type("{esc}");
   });
 
+  it("validates on blur", () => {
+    cy.get("#story--components-selects--rules-1 .a-select__selection")
+      .eq(0)
+      .tab()
+      .tab({shift: true})
+      .tab();
+    cy.get("#story--components-selects--rules-1 .a-input-base__hint")
+      .eq(0)
+      .contains("Role is required");
+  });
+
   it("validates", () => {
     cy.get("#story--components-selects--rules-1 .a-select__selection")
       .eq(0)

--- a/framework/components/ATextInput/ATextInput.js
+++ b/framework/components/ATextInput/ATextInput.js
@@ -346,7 +346,7 @@ const ATextInput = forwardRef(
       name,
       onBlur: (e) => {
         setIsFocused(false);
-        validateOnBlur && validate(e.target.value);
+        validate(e.target.value);
         onBlur && onBlur(e);
       },
       onChange: (e) => {
@@ -494,7 +494,7 @@ ATextInput.propTypes = {
    */
   type: PropTypes.oneOf(["text", "password", "email", "number"]),
   /**
-   * Sets the validation rules to evaluate on `blur` rather than on `change`.
+   * Delays validation until the `blur` event.
    */
   validateOnBlur: PropTypes.bool,
   /**

--- a/framework/components/ATextInput/ATextInput.spec.js
+++ b/framework/components/ATextInput/ATextInput.spec.js
@@ -184,6 +184,16 @@ context("ATextInput", () => {
       .should("have.length", 2);
   });
 
+  it("validates on blur", () => {
+    cy.get("#story--components-text-inputs--rules-1 .a-text-input__input")
+      .eq(0)
+      .click()
+      .tab();
+    cy.get("#story--components-text-inputs--rules-1 .a-input-base__hint")
+      .eq(0)
+      .contains("Name is required");
+  });
+
   it("supports maxLength", () => {
     cy.get("#story--components-text-inputs--rules-1 .a-text-input__input")
       .eq(0)

--- a/framework/components/ATextarea/ATextarea.js
+++ b/framework/components/ATextarea/ATextarea.js
@@ -157,7 +157,7 @@ const ATextarea = forwardRef(
       value,
       onBlur: (e) => {
         setIsFocused(false);
-        validateOnBlur && validate(e.target.value);
+        validate(e.target.value);
         onBlur && onBlur(e);
       },
       onChange: (e) => {
@@ -255,7 +255,7 @@ ATextarea.propTypes = {
     })
   ),
   /**
-   * Sets the validation rules to evaluate on `blur` rather than on `change`.
+   * Delays validation until the `blur` event.
    */
   validateOnBlur: PropTypes.bool,
   /**

--- a/framework/components/ATextarea/ATextarea.spec.js
+++ b/framework/components/ATextarea/ATextarea.spec.js
@@ -59,19 +59,29 @@ context("ATextarea", () => {
       .should("have.attr", "style", "height: auto;");
   });
 
+  it("validates on blur", () => {
+    cy.get("#story--components-textareas--rules-1 .a-textarea__field")
+      .eq(0)
+      .click();
+    cy.tab();
+    cy.get("#story--components-textareas--rules-1 .a-input-base__hint")
+      .eq(0)
+      .contains("Comments is required");
+  });
+
   it("validates", () => {
     cy.get("#story--components-textareas--rules-1 .a-textarea__field")
       .eq(0)
       .type("123456789012");
-    cy.get("#story--components-textareas--rules-1").click("left");
+    cy.tab();
     cy.get("#story--components-textareas--rules-1 .a-input-base__hint")
       .eq(0)
       .contains("Comments must be less than 10 characters");
 
     cy.get("#story--components-textareas--rules-1 .a-textarea__field")
       .eq(0)
-      .clear();
-    cy.get("#story--components-textareas--rules-1").click("left");
+      .clear()
+      .tab();
     cy.get("#story--components-textareas--rules-1 .a-input-base__hint")
       .eq(0)
       .contains("Comments is required");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.2.8",
+  "version": "2.2.9",
   "description": "",
   "main": "index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are documented in component docs and changelog
- [X] The ESLint plugin has been updated if a new component is added
- [X] Test have been added or modified, if appropriate
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

Ensures components that have the `validateOnBlur` prop validate on blur regardless of whether or not that is specified.

Before, the meaning of `validateOnBlur` toggled validation between `change` and `blur` events, but now it is restricted to disabling `change` validation. Like the documentation says "delays validation until the blur event".

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No
