### PR TITLE
fix: use correct aria role for tab list

### DIFF
--- a/.storybook/changelog.stories.mdx
+++ b/.storybook/changelog.stories.mdx
@@ -4,6 +4,10 @@ import {Meta} from "@storybook/addon-docs/blocks";
 
 # Changelog
 
+## 2.5.4
+
+- Fixed the aria role of `ATabGroup`
+
 ## 2.5.3
 
 Added the following icons:

--- a/framework/components/ATabs/ATabGroup.js
+++ b/framework/components/ATabs/ATabGroup.js
@@ -26,7 +26,7 @@ const ATabGroup = forwardRef(
     };
 
     return (
-      <div {...rest} role="tabslist" ref={ref} className={className}>
+      <div {...rest} role="tablist" ref={ref} className={className}>
         <ATabContext.Provider value={tabContext}>
           {children}
         </ATabContext.Provider>

--- a/framework/components/ATabs/ATabs.spec.js
+++ b/framework/components/ATabs/ATabs.spec.js
@@ -20,7 +20,7 @@ context("ATabs", () => {
   it("has appropriate roles", () => {
     cy.get("#story--components-tabs--usage-1 .a-tab-group")
       .eq(0)
-      .should("have.attr", "role", "tabslist");
+      .should("have.attr", "role", "tablist");
     cy.get("#story--components-tabs--usage-1 .a-tab-group__tab")
       .eq(0)
       .should("have.attr", "role", "tab")

--- a/framework/components/ATabs/ATabs.stories.mdx
+++ b/framework/components/ATabs/ATabs.stories.mdx
@@ -132,7 +132,7 @@ On `ATab`, set the `component` property to your router's link type, for example:
 
 ## Accessibility Notes
 
-By default, `ATabGroup` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [tabslist](https://www.w3.org/TR/wai-aria/#tabslist).
+By default, `ATabGroup` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [tablist](https://www.w3.org/TR/wai-aria/#tablist).
 
 By default, `ATab` components are assigned the [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/) role of [tab](https://www.w3.org/TR/wai-aria/#tab).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "",
   "main": "index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are documented in component docs and changelog
- [X] The ESLint plugin has been updated if a new component is added
- [X] Test have been added or modified, if appropriate
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

`ATabGroup` had the incorrect aria role, `tabslist` vs `tablist`

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No
