### PR TITLE
build: remove preferConst from rollup json plugin

### DIFF
--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -5,12 +5,10 @@ route: /changelog
 
 # Changelog
 
-## 2.9.0
-
-- Added scrolling feature to `ATabGroup`
-
 ## 2.8.0
 
+- Removed `preferConst` from rollup build's json plugin
+- Added scrolling feature to `ATabGroup`
 - Added `ASlider` component
 - Added `AFieldBase` base component
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.6.0",
+  "version": "2.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.6.0",
+  "version": "2.8.0",
   "description": "",
   "main": "index.js",
   "module": "lib/index.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -46,8 +46,7 @@ const config = {
   external: ["react", "react-dom"],
   plugins: [
     json({
-      compact: true,
-      preferConst: true
+      compact: true
     }),
     postcss({
       config: false,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are documented in component docs and changelog
- [X] The ESLint plugin has been updated if a new component is added
- [X] Test have been added or modified, if appropriate
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

Since the new `module` icon was added, some users have been experiencing issues with the rollup output -- it splits out json properties as global variables. Robert Harris reported that removing `preferConst` from the rollup json plugin configuration fixes the issue.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No
