### PR TITLE
feat: add isDark convenience flag to AThemeContext

### DIFF
--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -5,6 +5,10 @@ route: /changelog
 
 # Changelog
 
+## 2.13.4 (2021-05-19)
+
+- Added the `isDark` boolean to useATheme hook
+
 ## 2.13.3 (2021-04-02)
 
 - Added the `created`, `registered`, `unregistered` icons

--- a/framework/components/ATheme/ATheme.js
+++ b/framework/components/ATheme/ATheme.js
@@ -12,6 +12,8 @@ const ATheme = forwardRef(
     ref
   ) => {
     const [currentTheme, setCurrentTheme] = useState("dusk");
+    const isDark = currentTheme === "dusk"
+    const isLight = currentTheme !== "dusk"
 
     useIsomorphicLayoutEffect(() => {
       let initialTheme = "default";
@@ -35,6 +37,8 @@ const ATheme = forwardRef(
 
     const themeContext = {
       currentTheme,
+      isDark,
+      isLight,
       setCurrentTheme: (theme) => {
         const newTheme = theme === "dusk" ? theme : "default";
         persist && localStorage?.setItem(LS_KEY, newTheme);

--- a/framework/components/ATheme/ATheme.mdx
+++ b/framework/components/ATheme/ATheme.mdx
@@ -33,12 +33,13 @@ import {useATheme} from "@cisco-ats/atomic-react/ATheme";
 <Playground
   noInline
   code={`const ThemeSwitcher = () => {
-  const {currentTheme, setCurrentTheme} = useATheme();
+  const {currentTheme, setCurrentTheme, isDark, isLight} = useATheme();
   return (
     <div
       style={{
         padding: 20,
-        backgroundColor: currentTheme === "default" ? "#fff" : "#000"
+        backgroundColor: currentTheme === "default" ? "#eee" : "#000",
+        color: currentTheme === "default" ? "#000" : "#eee",
       }}>
       <AButtonGroup
         selectedValues={[currentTheme]}
@@ -46,6 +47,9 @@ import {useATheme} from "@cisco-ats/atomic-react/ATheme";
         <AButton value="default">Default</AButton>
         <AButton value="dusk">Dusk</AButton>
       </AButtonGroup>
+      <hr/>
+      <div>isDark: {isDark.toString()}</div>
+      <div>isLight: {isLight.toString()}</div>
     </div>
   );
 };

--- a/framework/components/ATheme/AThemeContext.js
+++ b/framework/components/ATheme/AThemeContext.js
@@ -2,6 +2,8 @@ import React from "react";
 
 const AThemeContext = React.createContext({
   currentTheme: "default",
+  isDark: false,
+  isLight: true,
   setCurrentTheme: () => {}
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cisco-ats/atomic-react",
-      "version": "2.13.3",
+      "version": "2.13.4",
       "license": "ISC",
       "dependencies": {
         "babel-plugin-auto-import": "1.1.0"
@@ -14262,6 +14262,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-ats/atomic-react",
-  "version": "2.13.3",
+  "version": "2.13.4",
   "description": "",
   "main": "index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [x] The changes are documented in component docs and changelog
- [x] The ESLint plugin has been updated if a new component is added
- [x] Test have been added or modified, if appropriate
- [x] Has been verified locally


**What kind of change does this PR introduce?**
Closes #572

Feature: Adds `isDark` boolean to ATThemeContext

**Does this PR introduce a breaking change?** 
No



