### PR TITLE
fix: handle null ref in a-menu

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "module": true,
     "require": true,
     "Buffer": true,
+    "process": true,
     "__dirname": true
   },
   "plugins": ["react-hooks"],

--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -5,6 +5,10 @@ route: /changelog
 
 # Changelog
 
+## 3.0.2 (2021-08-16)
+
+- Fixed null `ref` issue with `AMenu` occurring during jest-enzyme testing.
+
 ## 3.0.1 (2021-08-05)
 
 **BREAKING CHANGES**:

--- a/framework/components/AMenu/AMenu.js
+++ b/framework/components/AMenu/AMenu.js
@@ -33,7 +33,7 @@ const AMenu = forwardRef(
     useEffect(() => {
       if (open && focusOnOpen) {
         setTimeout(() => {
-          combinedRef.current.focus();
+          combinedRef.current?.focus();
         }, 0);
       }
     }, [open, combinedRef, focusOnOpen]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cisco-sbg-ui/atomic-react",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cisco-sbg-ui/atomic-react",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "ISC",
       "dependencies": {
         "babel-plugin-auto-import": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-sbg-ui/atomic-react",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "",
   "main": "lib/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are documented in component docs and changelog
- [X] The ESLint plugin has been updated if a new component is added
- [X] Test have been added or modified, if appropriate
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

Adds a check for a null `ref` in `AMenu` which causes issues for jest-enzyme tests.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No
