### PR TITLE
build: limit algolia excerpts to 5000 characters

### DIFF
--- a/scripts/algolia.js
+++ b/scripts/algolia.js
@@ -32,7 +32,7 @@ const updateAlgolia = async () => {
       route: data.route,
       name: data.name,
       components,
-      excerpt:
+      excerpt: (
         removeMd(
           content
             .replace(/<Playground(.+?)\r?\n`}\r?\n\/>/gs, "")
@@ -49,6 +49,7 @@ const updateAlgolia = async () => {
             )
             .filter(Boolean)
             .join(" ") || ""
+      ).substr(0, 5000)
     };
   });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit message follows semantic commit message guidelines
- [X] The changes are documented in component docs and changelog
- [X] The ESLint plugin has been updated if a new component is added
- [X] Test have been added or modified, if appropriate
- [X] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->

Algolia was erroring on search items being too large. This PR adds a limit to 5000 characters on the `excerpt`, whereas the individual item size limit is 10kb (10000 characters).

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No
