### PR TITLE
Expandable datatable rows

### DIFF
--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import PropTypes from "prop-types";
-import React, {forwardRef, useEffect, useMemo, useRef, useState} from "react";
+import React, {forwardRef, useMemo, useRef, useState} from "react";
 
 import AIcon from "../AIcon";
 import ASimpleTable from "../ASimpleTable";

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -1,17 +1,39 @@
+import _ from "lodash";
 import PropTypes from "prop-types";
-import React, {forwardRef} from "react";
+import React, {forwardRef, useEffect, useMemo, useRef, useState} from "react";
 
 import AIcon from "../AIcon";
 import ASimpleTable from "../ASimpleTable";
 import "./ADataTable.scss";
 
-const ADataTable = forwardRef(
-  ({className: propsClassName, headers, items, onSort, sort, ...rest}, ref) => {
-    let className = "a-data-table";
+const TableHeader = (props) => <th role='columnheader' {...props} />;
+const TableRow = (props) => <tr role='row' {...props} />;
+const TableCell = (props) => <td role='cell' {...props} />;
+const uniqueRowId = Symbol('uuid');
 
+const ADataTable = forwardRef(
+  ({className: propsClassName, expandable, headers, items: propsItems, onSort, sort, ...rest}, ref) => {
+    const uniqueIdRef = useRef(_.uniqueId('a-data-table-'));
+    const [expandedRows, setExpandedRows] = useState({});
+    const uniqueTableId = uniqueIdRef.current;
+    const rowData = JSON.stringify(propsItems);
+    const ExpandableComponent = expandable?.component;
+    // Helps keep row state stable between renders (expansion, selection, etc.)
+    const items = useMemo(() => propsItems.map(i => ({...i, [uniqueRowId]: _.uniqueId(`${uniqueTableId}-`)}))
+    , [uniqueTableId, rowData]); // eslint-disable-line react-hooks/exhaustive-deps
+    let className = 'a-data-table';
+    if (ExpandableComponent) {
+      className += '--expandable'
+    }
     if (propsClassName) {
       className += ` ${propsClassName}`;
     }
+
+    const toggleRow = (uuid) => {
+      return () => {
+        setExpandedRows(prev => ({...prev, [uuid]: !prev[uuid]}))
+      }
+    };
 
     let sortedItems = items;
     if (sort) {
@@ -39,7 +61,8 @@ const ADataTable = forwardRef(
         <ASimpleTable {...rest} ref={ref} className={className}>
           {headers && (
             <thead>
-              <tr>
+              <TableRow>
+                {ExpandableComponent && <TableHeader><span>Toggle</span></TableHeader>}
                 {headers.map((x, i) => {
                   const headerProps = {
                     className: `a-data-table__header ${
@@ -88,7 +111,7 @@ const ADataTable = forwardRef(
                   }
 
                   return (
-                    <th {...headerProps} key={`a-data-table_header_${i}`}>
+                    <TableHeader {...headerProps} key={`a-data-table_header_${i}`}>
                       {x.align !== "end" && x.name}
                       {x.sortable && (
                         <AIcon
@@ -107,28 +130,63 @@ const ADataTable = forwardRef(
                         </AIcon>
                       )}
                       {x.align === "end" && x.name}
-                    </th>
+                    </TableHeader>
                   );
                 })}
-              </tr>
+                {ExpandableComponent && <TableHeader>Additional Details</TableHeader>}
+              </TableRow>
             </thead>
           )}
           <tbody>
-            {sortedItems.map((x, i) => (
-              <tr key={`a-data-table_row_${i}`}>
-                {headers.map((y, j) => (
-                  <td
-                    key={`a-data-table_cell_${j}`}
-                    className={`text-${y.align || "start"} ${
-                      y.cell?.className || ""
-                    }`.trim()}>
-                    {y.cell && y.cell.component
-                      ? y.cell.component(x)
-                      : x[y.key]}
-                  </td>
-                ))}
-              </tr>
-            ))}
+            {sortedItems.map((x) => {
+              const hasExpandedRowContent = ExpandableComponent &&
+                (typeof expandable.isRowExpandable === 'function'
+                  ? expandable.isRowExpandable(x)
+                  : true
+                );
+              const uuid = x[uniqueRowId];
+              return (
+                <TableRow data-expandable-row={hasExpandedRowContent} key={uuid} className='a-data-table__row'>
+                  {ExpandableComponent && (
+                    <TableCell>
+                      {hasExpandedRowContent && (
+                        <button
+                          aria-expanded={expandedRows[uuid]}
+                          aria-controls={uuid}
+                          className='a-data-table--expandable__cell__btn'
+                          onClick={toggleRow(uuid)}>
+                          <AIcon size={12}>
+                            {expandedRows[uuid] ? "chevron-down" : "chevron-right"}
+                          </AIcon>
+                        </button>
+                      )}
+                    </TableCell>
+                  )}
+                  {headers.map((y, j) => (
+                    <TableCell
+                      key={`a-data-table_cell_${j}`}
+                      className={`text-${y.align || "start"} ${
+                        y.cell?.className || ""
+                      }`.trim()}
+                      role='cell'>
+                      {y.cell && y.cell.component
+                        ? y.cell.component(x)
+                        : x[y.key]}
+                    </TableCell>
+                  ))}
+                  {hasExpandedRowContent && (
+                    <TableCell
+                      {..._.omit(expandable, ['component', 'isRowExpandable'])}
+                      id={uuid}
+                      data-expandable-content
+                      hidden={!expandedRows[uuid]}
+                      role='cell'>
+                      <ExpandableComponent {...x} />
+                    </TableCell>
+                  )}
+                </TableRow>
+              )
+            })}
           </tbody>
         </ASimpleTable>
       )
@@ -142,6 +200,18 @@ ADataTable.propTypes = {
    */
   altLinks: PropTypes.bool,
   /**
+   * Configuration object for expandable table rows
+   */
+  expandable: PropTypes.shape({
+    /** The component to be rendered on expansion */
+    component: PropTypes.func.isRequired,
+    /**
+     * (optional): A function called when rendering each row to determine
+     * if the row can be expanded an collapsed
+     */
+    isRowExpandable: PropTypes.func,
+  }),
+  /**
    * Sets the table headers.
    */
   headers: PropTypes.arrayOf(
@@ -154,7 +224,7 @@ ADataTable.propTypes = {
       className: PropTypes.string,
       /** The alignment of the header column text content */
       align: PropTypes.oneOf(["start", "center", "end"]),
-      /** Determinees if the column can be sorted by the user */
+      /** Determines if the column can be sorted by the user */
       sortable: PropTypes.bool,
       /** Sorting function for the column data */
       sort: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -148,7 +148,7 @@ ADataTable.propTypes = {
     PropTypes.shape({
       /** The text to be displayed in the header column */
       name: PropTypes.string,
-      /** Unique identifier used to assist in table sorting */
+      /** The unique identifier to associate a column with subsequent row data */
       key: PropTypes.string,
       /** CSS class used to style the header column */
       className: PropTypes.string,

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -89,7 +89,7 @@ const ADataTable = forwardRef(
 
                   return (
                     <th {...headerProps} key={`a-data-table_header_${i}`}>
-                      {x.align !== "end" ? x.name : ""}
+                      {x.align !== "end" && x.name}
                       {x.sortable && (
                         <AIcon
                           left={x.align === "end"}
@@ -106,7 +106,7 @@ const ADataTable = forwardRef(
                             : "chevron-up"}
                         </AIcon>
                       )}
-                      {x.align === "end" ? x.name : ""}
+                      {x.align === "end" && x.name}
                     </th>
                   );
                 })}

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -146,14 +146,23 @@ ADataTable.propTypes = {
    */
   headers: PropTypes.arrayOf(
     PropTypes.shape({
+      /** The text to be displayed in the header column */
       name: PropTypes.string,
+      /** Unique identifier used to assist in table sorting */
       key: PropTypes.string,
+      /** CSS class used to style the header column */
       className: PropTypes.string,
+      /** The alignment of the header column text content */
       align: PropTypes.oneOf(["start", "center", "end"]),
+      /** Determinees if the column can be sorted by the user */
       sortable: PropTypes.bool,
+      /** Sorting function for the column data */
       sort: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
+      /** Object that refers to the column's associated data table cells, i.e., <td /> elements */
       cell: PropTypes.shape({
+        /** Class to be added to each table data element */
         className: PropTypes.string,
+        /** Custom component to be rendered for each table data item */
         component: PropTypes.func
       })
     })

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -90,6 +90,175 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
 `}
 />
 
+## Expandable Rows
+
+<Playground
+  code={`() => {
+  const [sort, setSort] = useState();
+  const headers = [
+    {
+      name: "alpha",
+      key: "a",
+      align: "start",
+      className: "text-capitalize",
+      sortable: true
+    },
+    {
+      name: "Bravo",
+      key: "b",
+      align: "center",
+      sortable: true,
+      sort: false
+    },
+    {
+      name: "Charlie",
+      key: "c",
+      sortable: true,
+      sort: (a, b) =>
+        a.toUpperCase() === b.toUpperCase()
+          ? 0
+          : a.toUpperCase() > b.toUpperCase()
+          ? 1
+          : -1
+    },
+    {
+      name: "Delta",
+      align: "center",
+      cell: {
+        component: (item) => (
+          <a href="/" target="_blank">
+            Details
+          </a>
+        )
+      }
+    }
+  ];
+  const items = [
+    {
+      a: 11.1,
+      b: 526,
+      c: "aardvark"
+    },
+    {
+      a: 8.9,
+      b: 611,
+      c: "Argentina"
+    },
+    {
+      a: 10.5,
+      b: 475,
+      c: "Zanzibar"
+    }
+  ];
+  const expandableConfig = {
+    component: (props) => (
+      <p>
+        Additional information about {props.a} and {props.b}.
+      </p>
+    )
+  }
+  return (
+    <ADataTable
+      striped
+      tight
+      headers={headers}
+      items={items}
+      expandable={expandableConfig}
+      className="mx-auto"
+      style={{maxWidth: 500}}
+      sort={sort}
+      onSort={(s) => setSort(s)}
+    />
+  );
+}
+`}
+/>
+
+## Conditional Expandable Rows
+
+<Playground
+  code={`() => {
+  const [sort, setSort] = useState();
+  const headers = [
+    {
+      name: "alpha",
+      key: "a",
+      align: "left",
+      className: "text-capitalize",
+      sortable: true
+    },
+    {
+      name: "Bravo",
+      key: "b",
+      align: "center",
+      sortable: true,
+      sort: false
+    },
+    {
+      name: "Charlie",
+      key: "c",
+      sortable: true,
+      sort: (a, b) =>
+        a.toUpperCase() === b.toUpperCase()
+          ? 0
+          : a.toUpperCase() > b.toUpperCase()
+          ? 1
+          : -1
+    },
+    {
+      name: "Delta",
+      align: "center",
+      cell: {
+        component: (item) => (
+          <a href="/" target="_blank">
+            Details
+          </a>
+        )
+      }
+    }
+  ];
+  const items = [
+    {
+      a: 11.1,
+      b: 526,
+      c: "aardvark"
+    },
+    {
+      a: 8.9,
+      b: 611,
+      c: "Argentina"
+    },
+    {
+      a: 10.5,
+      b: 475,
+      c: "Zanzibar"
+    }
+  ];
+  const expandableConfig = {
+    isRowExpandable: (rowData) => rowData.a > 10,
+    component: (props) => (
+      <p>
+        Column "a" of row {props.c} has a value greater than 10.
+      </p>
+    )
+  }
+  return (
+    <ADataTable
+      striped
+      tight
+      headers={headers}
+      items={items}
+      expandable={expandableConfig}
+      className="mx-auto"
+      style={{maxWidth: 500}}
+      sort={sort}
+      onSort={(s) => setSort(s)}
+    />
+  );
+}
+`}
+/>
+
 ## Data Table Props
 
 The `ADataTable` component inherits passed props.

--- a/framework/components/ADataTable/ADataTable.scss
+++ b/framework/components/ADataTable/ADataTable.scss
@@ -1,5 +1,112 @@
 @import "../../styles";
 
+@include theme(a-data-table--expandable) using ($theme) {
+  & tr {
+    display: flex;
+    flex-flow: row wrap;
+    height: 100%;
+    min-height: 30px;
+
+    &[data-expandable-row="true"] {
+      & td:nth-last-child(2) {
+        border-right-width: $border-width;
+        border-right-style: solid;
+        border-right-color: map-deep-get($theme, "control", "stroke-color");
+      }
+    }
+
+    & th {
+      flex: 1;
+      line-height: 200%;
+      &:first-child {
+        border-right: none;
+        min-width: 30px;
+        flex-basis: 0;
+        flex-grow: 0;
+
+        & > span {
+          @include sr-only;
+        }
+      }
+      &:nth-child(2) {
+        border-left: none;
+        padding-left: 0;
+      }
+      &:last-of-type {
+        position: absolute;
+        height: 1px;
+        width: 1px;
+        overflow: hidden;
+        clip: rect(1px 1px 1px 1px);
+        clip: rect(1px, 1px, 1px, 1px);
+      }
+    }
+
+    & td {
+      display: block;
+      flex: 1;
+      line-height: 200%;
+
+      /** 
+        * The cells which contains button(s) to toggle content.
+        * While some cells might not have the expand button, they
+        * still need to be styled to match sibling cells which
+        * do render a button
+        */
+      &:first-child {
+        flex: 0;
+        display: flex;
+        align-items: center;
+        min-width: 30px;
+        padding: 0;
+
+        /* Button to expand content */
+        & button {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          padding: 0;
+          width: 100%;
+          height: 100%;
+          background: transparent;
+          border: none;
+          color: unset;
+          font-family: inherit;
+        }
+      }
+
+      /* The first cell in which a library consumer's content renders */
+      &:nth-child(2) {
+        padding-left: 0;
+      }
+
+      /* The cell that contains the hidden content */
+      &:last-child[data-expandable-content] {
+        display: block;
+        padding: 0 10px;
+        visibility: visible;
+        overflow: hidden;
+        max-height: 600px;
+        opacity: 1;
+        flex-basis: 100%;
+        border-width: $border-width;
+        border-style: solid;
+        border-color: map-deep-get($theme, "control", "stroke-color");
+        background: map-deep-get($theme, "table", "row-hover-color");
+        border-top: none;
+        border-bottom: none;
+
+        &[hidden] {
+          max-height: 0;
+          visibility: hidden;
+          opacity: 0;
+          padding: unset;
+        }
+      }
+    }
+  }
+}
+
 .a-data-table {
   &__header {
     &__sort {

--- a/framework/styles/utilities/mixins.scss
+++ b/framework/styles/utilities/mixins.scss
@@ -88,3 +88,20 @@
 @mixin tab-bar($tab-bar-height, $tab-bar-color) {
   box-shadow: inset 0 $tab-bar-height 0 -1px $tab-bar-color;
 }
+
+// -----------------------------------------------------------------------------
+// Content exclusively for screen readers
+// -----------------------------------------------------------------------------
+@mixin sr-only {
+  border: 0 !important;
+	clip: rect(1px, 1px, 1px, 1px) !important;
+	-webkit-clip-path: inset(50%) !important;
+	clip-path: inset(50%) !important;
+	height: 1px !important;
+	margin: -1px !important;
+	overflow: hidden !important;
+	padding: 0 !important;
+	position: absolute !important;
+	width: 1px !important;
+	white-space: nowrap !important;
+}


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
<!--A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]-->

As a developer I need expandable rows in my datatables.

**Describe the solution you'd like**
<!--A clear and concise description of what you want to happen.-->

The "alternate version" (bottom) of this:

![image](https://user-images.githubusercontent.com/14955351/143291225-95824487-76f6-4a78-88ab-32a50bcc6a25.png)

To achieve this, you'll need a prop to toggle, `expandableRows`, that has the effect of inserting a chevron table cell in each row, and inserting an alternate row after every data row. On chevron click, alternate row expands/contracts. Notice the first cell with the chevron has no header cell, so the first user-defined header cell needs it's `colspan` modified.

Define the alternate row content somewhere in the datatable's json content.
