### PR TITLE
fix: properly detect system auto theme on page refresh

### DIFF
--- a/framework/components/AAutoTheme/AAutoTheme.js
+++ b/framework/components/AAutoTheme/AAutoTheme.js
@@ -21,17 +21,6 @@ const AAutoTheme = (props) => {
         }
       });
 
-    useIsomorphicLayoutEffect(() => {
-      if (persist && localStorage.getItem(persistKey) === "enabled") {
-        setIsEnabled(true);
-        return;
-      }
-      if (persist && localStorage.getItem(persistKey) === "disabled") {
-        setIsEnabled(false);
-        return;
-      }
-    }, []);
-
     const enable = useCallback(() => {
       setIsEnabled(true);
       prevSelectedTheme.current = currentTheme;
@@ -39,7 +28,7 @@ const AAutoTheme = (props) => {
       if (persist) {
         localStorage.setItem(persistKey, "enabled");
       }
-    }, [currentTheme, matches, persist, setCurrentTheme, setIsEnabled])
+    }, [currentTheme, matches, persist, setCurrentTheme, setIsEnabled]);
 
     const disable = useCallback(() => {
       setIsEnabled(false);
@@ -47,16 +36,27 @@ const AAutoTheme = (props) => {
       if (persist) {
         localStorage.setItem(persistKey, "disabled");
       }
-    }, [setCurrentTheme, setIsEnabled, persist])
+    }, [setCurrentTheme, setIsEnabled, persist]);
+
+    useIsomorphicLayoutEffect(() => {
+      if (persist && localStorage.getItem(persistKey) === "enabled") {
+        enable();
+        return;
+      }
+      if (persist && localStorage.getItem(persistKey) === "disabled") {
+        disable();
+        return;
+      }
+    }, []);
 
     const ctx = useMemo(() => ({
         enabled: isEnabled,
         enable,
         disable,
         toggle: () => {
-          setIsEnabled(prev => prev ? disable() : enable())
+          isEnabled ? disable() : enable();
         }
-    }), [isEnabled, setIsEnabled, enable, disable])
+    }), [isEnabled, enable, disable]);
 
     return (
         <AAutoThemeContext.Provider value={ctx}>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


**What kind of change does this PR introduce?**

Fixes an issue when a user refreshes their page and automatic theming was previously enabled.

**What is the current behavior?** <!--(You can also link to an open issue here)-->

Theming was automatically being set to the color mode from the user's last visit, regardless of the system theme's preferences.

**What is the new behavior (if this is a feature change)?**

Properly enables or disables the automatic theming when initially rendering the application, i.e., explicitly calling `enable()` and `disable()` from the `useAAutoTheme` hook.


**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No

**Other information**:


