### PR TITLE
build: re-include framework directory in package contents

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,6 @@ build/
 coverage/
 cypress/
 docs/
-framework/
 pages/
 public/
 scripts/

--- a/docs/ThemeSwitcher.js
+++ b/docs/ThemeSwitcher.js
@@ -19,7 +19,7 @@ const ThemeSwitcher = () => {
             setCurrentTheme(value);
           }}
         >
-          <AButton style={{color: 'white'}} disabled={autoTheme.enabled} value='default'>Light</AButton>
+          <AButton data-testid="enable-default-theme" style={{color: 'white'}} disabled={autoTheme.enabled} value='default'>Light</AButton>
           <AButton data-testid="enable-dusk-theme" style={{color: 'white'}} disabled={autoTheme.enabled} value='dusk'>Dusk</AButton>
         </AButtonGroup>
       </div>

--- a/framework/components/AAutoTheme/AAutoTheme.spec.js
+++ b/framework/components/AAutoTheme/AAutoTheme.spec.js
@@ -23,5 +23,25 @@ context("AAutoTheme", () => {
     cy.get(".root-sidebar .a-switch").compareSnapshot(
       "AutoTheme 2"
     );
-    });
+
+    // Turn auto theming off - when the automatic theming is disabled,
+    // it should keep whatever theme the automatic theme was set to
+    cy.get(".root-sidebar .a-switch__box").eq(0).click();
+    cy.get(".root-sidebar .a-switch").compareSnapshot(
+      "AutoTheme 2"
+    );
+
+   // Switch back to light theme
+    cy.get("[data-testid='enable-default-theme']").eq(0).click();
+    cy.get(".root-sidebar .a-switch").compareSnapshot(
+      "AutoTheme 1"
+    );
+
+    // When re-enabling automatic theming, it should match the user agent
+    // style sheet (in this cae it is dark mode);
+    cy.get(".root-sidebar .a-switch__box").eq(0).click();
+    cy.get(".root-sidebar .a-switch").compareSnapshot(
+      "AutoTheme 2"
+    );
+  });
 })

--- a/framework/components/ADatePicker/ADatePicker.js
+++ b/framework/components/ADatePicker/ADatePicker.js
@@ -25,28 +25,26 @@ const fullMonthNames = [
   "December"
 ];
 
-const getInitialCalendarSelection = (value) => {
-  const isRange = Array.isArray(value);
-
-  if (!isRange) {
-    return value;
-  }
-
-  // If range has a Date object, use the latest one
-  // to initialize the calendar UI
-  const dates = value.filter(d => d instanceof Date);
-  if (!dates.length) {
-    return new Date();
-  }
-  return sortDates(dates)[dates.length - 1];
-};
-
 const ICON_SIZE = 10;
 
 const ADatePicker = forwardRef(
   ({className: propsClassName, onChange, value = new Date(), ...rest}, ref) => {
     const isRange = Array.isArray(value);
-    const [calendarDate, setCalendarDate] = useState(() => getInitialCalendarSelection(value));
+    const [calendarDate, setCalendarDate] = useState(() => {
+      const isRange = Array.isArray(value);
+
+      if (!isRange) {
+        return value;
+      }
+    
+      // If range has a Date object, use the latest one
+      // to initialize the calendar UI
+      const dates = value.filter(d => d instanceof Date);
+      if (!dates.length) {
+        return new Date();
+      }
+      return sortDates(dates)[dates.length - 1];
+    });
     const firstCalendarDate = useMemo(() => {
       let currDate = new Date(
         calendarDate.getFullYear(),

--- a/framework/components/ADatePicker/helpers.js
+++ b/framework/components/ADatePicker/helpers.js
@@ -1,14 +1,14 @@
-export const sortDates = (dates) => {
+const sortDates = (dates) => {
     return dates.sort((a, b) => Date.parse(a) - Date.parse(b));
 };
 
-export const isSameDate = (a, b) => {
+const isSameDate = (a, b) => {
     return a.getFullYear() === b.getFullYear() &&
         a.getMonth() === b.getMonth() &&
         a.getDate() === b.getDate()
 };
 
-export const isDateTipOfRange = (date, range) => {
+const isDateTipOfRange = (date, range) => {
     const [rangeStartDate, rangeEndDate] = range;
 
     if (
@@ -21,8 +21,15 @@ export const isDateTipOfRange = (date, range) => {
     return false;
 };
 
-export const isDateBetweenRange = (date, range) => {
+const isDateBetweenRange = (date, range) => {
     const [rangeStartDate, rangeEndDate] = range;
     return Date.parse(date) > Date.parse(rangeStartDate) &&
         Date.parse(date) < Date.parse(rangeEndDate);
 };
+
+export {
+    sortDates,
+    isSameDate,
+    isDateTipOfRange,
+    isDateBetweenRange
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


The purpose of this change is to re-include package contents that were going to be excluded from release 3.3.0 in order to keep them available for [applications currently importing them](https://github.com/advthreat/GLaDOS/blob/37178a21a45f1e43a3b50558373af80f0f246ffa/src/scss/recharts-overrides.scss#L1).

**What is the current behavior?** <!--(You can also link to an open issue here)-->

The `framework` directory is excluded from atomic-react package contents.


**What is the new behavior (if this is a feature change)?**

Re-includes the `framework` directory.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No

**Other information**:

We will want to revert applications importing files from `framework` to import from `lib` instead.
