### PR TITLE
feat: support minimum and maximum date selections in date picker

### DIFF
--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -5,6 +5,12 @@ route: /changelog
 
 # Changelog
 
+## 3.4.0 (3-15-2022)
+
+- Add `minDate` and `maxDate` props to `ADatePicker` to support restricting certain dates
+- Update `useADateRange` to take a configuration object in which an `initialRange` and `maxDays` can be defined
+- Fixes `ADatePicker` font color from changing as a side effect of an external component
+
 ## 3.3.0 (3-7-2022)
 
 - Swap documentation platform from Gatsby to Next.js

--- a/framework/components/ADatePicker/ADatePicker.js
+++ b/framework/components/ADatePicker/ADatePicker.js
@@ -28,7 +28,9 @@ const fullMonthNames = [
 const ICON_SIZE = 10;
 
 const ADatePicker = forwardRef(
-  ({className: propsClassName, onChange, value = new Date(), ...rest}, ref) => {
+  ({className: propsClassName, onChange, value = new Date(), minDate, maxDate, ...rest}, ref) => {
+    const hasMinDate = minDate instanceof Date;
+    const hasMaxDate = maxDate instanceof Date;
     const isRange = Array.isArray(value);
     const [calendarDate, setCalendarDate] = useState(() => {
       const isRange = Array.isArray(value);
@@ -137,7 +139,9 @@ const ADatePicker = forwardRef(
                   {[...Array(7)].map((y, j) => {
                     const currWeekDay = new Date(+sunday);
                     currWeekDay.setDate(currWeekDay.getDate() + j);
-                    const isDisabled = currWeekDay.getMonth() !== calendarDate.getMonth();
+                    const isBeforeMinDate = hasMinDate && Date.parse(currWeekDay) < Date.parse(minDate);
+                    const isPastMaxDate = hasMaxDate && Date.parse(currWeekDay) > Date.parse(maxDate);
+                    const isDisabled = currWeekDay.getMonth() !== calendarDate.getMonth() || isBeforeMinDate || isPastMaxDate;
                     const isSelected = isRange ?
                       isDateTipOfRange(currWeekDay, value) :
                       isSameDate(currWeekDay, value);
@@ -205,8 +209,16 @@ ADatePicker.propTypes = {
    */
   value: PropTypes.oneOfType([
     PropTypes.instanceOf(Date),
-    PropTypes.arrayOf(rangeTupleValidator),
-  ])
+    PropTypes.arrayOf(rangeTupleValidator)
+  ]),
+  /**
+   * The minimum date allowed for selection
+   */
+  minDate: PropTypes.instanceOf(Date),
+  /**
+   * The maximum date allowed for selection
+   */
+  maxDate: PropTypes.instanceOf(Date)
 };
 
 ADatePicker.displayName = "ADatePicker";

--- a/framework/components/ADatePicker/ADatePicker.js
+++ b/framework/components/ADatePicker/ADatePicker.js
@@ -31,6 +31,15 @@ const ADatePicker = forwardRef(
   ({className: propsClassName, onChange, value = new Date(), minDate, maxDate, ...rest}, ref) => {
     const hasMinDate = minDate instanceof Date;
     const hasMaxDate = maxDate instanceof Date;
+    // Because date comparisons in this widget are ...
+    // ... only concerned with the day, reset the ...
+    // ... time to midnight for equal comparisons
+    if (hasMinDate) {
+      minDate.setHours(0, 0, 0, 0);
+    }
+    if (hasMaxDate) {
+      maxDate.setHours(0, 0, 0, 0);
+    }
     const isRange = Array.isArray(value);
     const [calendarDate, setCalendarDate] = useState(() => {
       const isRange = Array.isArray(value);

--- a/framework/components/ADatePicker/ADatePicker.mdx
+++ b/framework/components/ADatePicker/ADatePicker.mdx
@@ -26,6 +26,23 @@ import {ADatePicker} from "@cisco-sbg-ui/atomic-react";
 `}
 />
 
+### With Minimum and Maximum Dates
+
+<Playground
+  code={`() => {
+  const yesterday = new Date();
+  const today = new Date(2022, 2, 15);
+  const tomorrow = new Date();
+  tomorrow.setDate(today.getDate() + 1);
+  yesterday.setDate(today.getDate() - 1);
+  const [date, setDate] = useState(today);
+  return (
+    <ADatePicker value={date} onChange={(date) => setDate(date)} minDate={yesterday} maxDate={tomorrow}/>
+  );
+}
+`}
+/>
+
 ## Date Range
 
 <Playground

--- a/framework/components/ADatePicker/ADatePicker.mdx
+++ b/framework/components/ADatePicker/ADatePicker.mdx
@@ -38,17 +38,45 @@ import {ADatePicker} from "@cisco-sbg-ui/atomic-react";
 `}
 />
 
-### Initial Range
+### Date Range with Initial Range
 
 <Playground
   code={`() => {
   const { value, onChange, } = useADateRange([new Date(2022, 2, 28), new Date(2022, 3, 5)]);
+  const [firstSelection, secondSelection] = value;
+  // You can destructure the values from useADateRange to use ...
+  // ... the date picker's range value in your component
   return (
-    <ADatePicker value={value} onChange={onChange} />
+    <>
+      <ADatePicker value={value} onChange={onChange} />
+        <p aria-live="polite">
+          Selected range: <i>{firstSelection && firstSelection.toLocaleDateString()} - {secondSelection && secondSelection.toLocaleDateString()}</i>
+        </p>
+    </>
   );
 }
 `}
 />
+
+### Date Range with Maximum Days
+<Playground
+  code={`() => {
+  const { value, ...datePickerProps } = useADateRange({maxDays: 3});
+  const [firstSelection, secondSelection] = value;
+  // Alternatively, you can spread out the remaining values ...
+  // ... to be passed to the date picker
+  return (
+    <>
+      <ADatePicker value={value} {...datePickerProps} />
+      <p aria-live="polite">
+        Selected range: <i>{firstSelection && firstSelection.toLocaleDateString()} - {secondSelection && secondSelection.toLocaleDateString()}</i>
+      </p>
+    </>
+  );
+}
+`}
+/>
+
 
 ## Date Picker Props
 

--- a/framework/components/ADatePicker/ADatePicker.mdx
+++ b/framework/components/ADatePicker/ADatePicker.mdx
@@ -61,7 +61,10 @@ import {ADatePicker} from "@cisco-sbg-ui/atomic-react";
 ### Date Range with Maximum Days
 <Playground
   code={`() => {
-  const { value, ...datePickerProps } = useADateRange({maxDays: 3});
+  const { value, ...datePickerProps } = useADateRange({
+    initialRange: [new Date(2022, 2, 14), new Date(2022, 2, 16)],
+    maxDays: 3
+  });
   const [firstSelection, secondSelection] = value;
   // Alternatively, you can spread out the remaining values ...
   // ... to be passed to the date picker

--- a/framework/components/ADatePicker/ADatePicker.spec.js
+++ b/framework/components/ADatePicker/ADatePicker.spec.js
@@ -66,4 +66,23 @@ context("ADatePicker", () => {
     cy.get(rangeSelector).contains("April");
     cy.get(`${rangeSelector} .a-date-picker__day.selected`).contains("5");
   });
+
+  const maxDaysSelector = "#date-range-with-maximum-days + .playground .a-date-picker";
+
+  it("only allows a maximum number of days to be selected in a range", () => {
+    // Select March 14, 2022
+    cy.get(`${maxDaysSelector} .a-date-picker__day`).eq(15).click();
+
+    // Two days before and after March 14 should be enabled
+    cy.get(`${maxDaysSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 5);
+  });
+
+  it("only allows a maximum number of days to be selected in a range", () => {
+    // Select March 16, 2022
+    cy.get(`${maxDaysSelector} .a-date-picker__day`).eq(17).click();
+
+    // All days in March should go back to being selectable
+    cy.get(`${maxDaysSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 31);
+  });
+  
 });

--- a/framework/components/ADatePicker/ADatePicker.spec.js
+++ b/framework/components/ADatePicker/ADatePicker.spec.js
@@ -29,7 +29,7 @@ context("ADatePicker", () => {
     );
   });
 
-  const rangeSelector = "#initial-range + .playground .a-date-picker";
+  const rangeSelector = "#date-range-with-initial-range + .playground .a-date-picker";
 
   it("selects the two outer bounds of a date range", () => {
     cy.get(`${rangeSelector} .a-date-picker__day`).eq(7).click();

--- a/framework/components/ADatePicker/ADatePicker.spec.js
+++ b/framework/components/ADatePicker/ADatePicker.spec.js
@@ -67,6 +67,12 @@ context("ADatePicker", () => {
     cy.get(`${rangeSelector} .a-date-picker__day.selected`).contains("5");
   });
 
+  const minAndMaxDateSelector = "#with-minimum-and-maximum-dates + .playground .a-date-picker";
+
+  it("restricts date day selections", () => {
+    cy.get(`${minAndMaxDateSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 3);
+  });
+
   const maxDaysSelector = "#date-range-with-maximum-days + .playground .a-date-picker";
 
   it("only allows a maximum number of days to be selected in a range", () => {

--- a/framework/components/ADatePicker/useADateRange.js
+++ b/framework/components/ADatePicker/useADateRange.js
@@ -40,9 +40,11 @@ const useADateRange = (config) => {
   let minDate, maxDate;
   if (maxDays && firstSelection && !secondSelection) {
     minDate = new Date();
-    minDate.setDate(firstSelection.getDate() - parseInt(maxDays));
+    // Offset by 1 since one date is already selected
+    minDate.setDate(firstSelection.getDate() - (parseInt(maxDays) - 1));
 
     maxDate = new Date();
+    // Offset by 1 since one date is already selected
     maxDate.setDate(firstSelection.getDate() + (parseInt(maxDays) - 1));
   }
   if (maxDays && firstSelection && secondSelection) {

--- a/framework/components/ADatePicker/useADateRange.js
+++ b/framework/components/ADatePicker/useADateRange.js
@@ -24,8 +24,22 @@ export const stepSequencer = (existingRange, nextDate) => {
  * Hook for storing date range state. Currently uses a step sequence, but has
  * room for flexibility in the future.
  */
-const useADateRange = (initialRange = [null, null]) => {
+const useADateRange = (initialRange = [null, null], config = {}) => {
+  const { maxDays = null } = config;
   const [range, setRange] = useState(initialRange);
+  const [firstSelection, secondSelection] = range;
+  let minDate, maxDate;
+  if (maxDays && firstSelection && !secondSelection) {
+    minDate = new Date();
+    minDate.setDate(firstSelection.getDate() - parseInt(maxDays));
+
+    maxDate = new Date();
+    maxDate.setDate(firstSelection.getDate() + (parseInt(maxDays) - 1));
+  }
+  if (maxDays && firstSelection && secondSelection) {
+    minDate = null;
+    maxDate = null;
+  }
 
   const onChange = useCallback((incomingDate) => {
     setRange(oldRange => stepSequencer(oldRange, incomingDate));
@@ -34,7 +48,8 @@ const useADateRange = (initialRange = [null, null]) => {
   return {
     value: range,
     onChange,
+    minDate,
+    maxDate,
   };
 };
-
 export default useADateRange;

--- a/framework/components/ADatePicker/useADateRange.js
+++ b/framework/components/ADatePicker/useADateRange.js
@@ -24,8 +24,17 @@ export const stepSequencer = (existingRange, nextDate) => {
  * Hook for storing date range state. Currently uses a step sequence, but has
  * room for flexibility in the future.
  */
-const useADateRange = (initialRange = [null, null], config = {}) => {
-  const { maxDays = null } = config;
+const useADateRange = (config) => {
+  // Support older version hook config
+  let initialRange;
+  let maxDays;
+  const isUsingOldParams = Array.isArray(config);
+  if (isUsingOldParams) {
+    initialRange = config || [null, null];
+  } else {
+    initialRange = Array.isArray(config?.initialRange) ? config.initialRange : [null, null];
+    maxDays = config?.maxDays || null;
+  }
   const [range, setRange] = useState(initialRange);
   const [firstSelection, secondSelection] = range;
   let minDate, maxDate;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [x] The changes are documented in component docs and changelog
- [x] The ESLint plugin has been updated if a new component is added
- [x] Test have been added or modified, if appropriate
- [x] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->
Supports #1168 in restricting certain days from being selected inside the `ADatePicker`.

**What is the current behavior?** <!--(You can also link to an open issue here)-->

There are no restrictions for selecting a date inside `ADatePicker`.


**What is the new behavior (if this is a feature change)?**

Adds `minDate` and `maxDate` props to `ADatePicker` to indicate a range in which a user can select their date(s).

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No, but in future releases, I will be updating the `useADateRange` hook to *only* take a single configuration object. As it stands with this PR, you can pass in an array as an initial range (to support backwards compatibility with version 3.3.0), or a configuration object (introduced in this PR) to set both the initial range and a maximum number of days the user can select in the range.

```javascript
// Old (still compatible)
const today = new Date();
const aFewDays = new Date();
tomorrow.setDate(today.getDate() + 3);

const datePickerProps = useADateRange([today, aFewDays]);

// New
const today = new Date();
const aFewDays = new Date();
tomorrow.setDate(today.getDate() + 3);

const datePickerProps = useADateRange({
  initialRange: [today, aFewDays],
  // Can also set a max days selected in config
  maxDays: 4,
});
```

The newly introduced configuration object takes the `initialRange: [Date, Date]` and `maxDays: number` as key/value pairs.