### PR TITLE
fix: min and max date picker range issues

### DIFF
--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -5,6 +5,10 @@ route: /changelog
 
 # Changelog
 
+## 3.4.1 (3-16-2022)
+
+- Fix `useADateRange` minimum and maximum date calculation
+
 ## 3.4.0 (3-16-2022)
 
 - Add `minDate` and `maxDate` props to `ADatePicker` to support restricting certain dates

--- a/framework/components/ADatePicker/ADatePicker.spec.js
+++ b/framework/components/ADatePicker/ADatePicker.spec.js
@@ -91,4 +91,14 @@ context("ADatePicker", () => {
     cy.get(`${maxDaysSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 31);
   });
   
+  it("allows a maximum number of days to be selected in previous subsequent months", () => {
+    // Select January 14, 2022
+    cy.get(`${maxDaysSelector} .a-date-picker__prev`).click();
+    cy.get(`${maxDaysSelector} .a-date-picker__prev`).click();
+    cy.get(`${maxDaysSelector} .a-date-picker__day`).eq(20).click();
+
+    // Two days before and after January 14 should be enabled
+    cy.get(`${maxDaysSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 5);    
+  });
+
 });

--- a/framework/components/ADatePicker/useADateRange.js
+++ b/framework/components/ADatePicker/useADateRange.js
@@ -39,11 +39,11 @@ const useADateRange = (config) => {
   const [firstSelection, secondSelection] = range;
   let minDate, maxDate;
   if (maxDays && firstSelection && !secondSelection) {
-    minDate = new Date();
+    minDate = new Date(firstSelection);
     // Offset by 1 since one date is already selected
     minDate.setDate(firstSelection.getDate() - (parseInt(maxDays) - 1));
 
-    maxDate = new Date();
+    maxDate = new Date(firstSelection);
     // Offset by 1 since one date is already selected
     maxDate.setDate(firstSelection.getDate() + (parseInt(maxDays) - 1));
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-sbg-ui/atomic-react",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "",
   "main": "lib/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->

Fixes the issue of all the days in the month being disabled inside an `ADatePicker` with a range restriction.

**What is the current behavior?** <!--(You can also link to an open issue here)-->

The calculation for the min and max date is assuming that the first date picker selection is in the current month.

```js
minDate = new Date()
maxDate = new Date()
```


**What is the new behavior (if this is a feature change)?**

Initialized both the min and max date instances with the first date selection to serve as a base for the calculations.

```js
minDate = new Date(firstDateSelection)
maxDate = new Date(firstDateSelection)
```