### PR TITLE
feat: add infinite scrolling to ADataTable

### DIFF
--- a/docs/Playground.js
+++ b/docs/Playground.js
@@ -6,6 +6,7 @@ import {LiveProvider, LiveEditor, LiveError, LivePreview} from "react-live";
 import * as AtomicReactComponents from "../framework";
 import {AList} from "../framework";
 import LoremIpsum from "../framework/utils/lorem-ipsum";
+import mockImport from "./mock_modules";
 
 const scope = {
   ...AtomicReactComponents,
@@ -15,7 +16,8 @@ const scope = {
   useRef,
   useState,
   algoliasearch,
-  debounce
+  debounce,
+  mockImport
 };
 
 const Playground = ({code, fullWidthPreview, noInline}) => {

--- a/docs/mock_modules.js
+++ b/docs/mock_modules.js
@@ -1,0 +1,43 @@
+const modules = {
+  randomColors: (function() {
+    const getHex = (num) => num.toString(16).padStart(2, '0');
+    const getRandomRgb = () => {
+      const r = Math.floor(Math.random() * 256);
+      const g = Math.floor(Math.random() * 256);
+      const b = Math.floor(Math.random() * 256);
+      return {r, g, b};
+    };
+    const rgbToHex = ({r, g, b}) => {
+      const rHex = getHex(r), gHex = getHex(g), bHex = getHex(b);
+      return '#' + rHex + gHex + bHex;
+    };
+    const generateRandomColors = (maxColors = 25) => {
+      const colors = [];
+      for (let i = 0; i <= maxColors - 1; i++) {
+        const rgb = getRandomRgb();
+        const hex = rgbToHex(rgb);
+        colors.push({
+          ...rgb,
+          hex,
+        });
+      };
+      return colors;
+    };
+    const get = (num = 25) => {
+      return new Promise((resolve) => {
+        setTimeout(() => resolve(generateRandomColors(num)), 1000);
+      });
+    };
+    return { get };
+  })(),
+}
+
+function mockImport(moduleName) {
+  const requestedModule = modules[moduleName];
+  if (!requestedModule) {
+    throw new Error(`Mock module "${moduleName}" was not found in Playground editor`);
+  }
+  return requestedModule;
+}
+
+export default mockImport;

--- a/docs/mock_modules.js
+++ b/docs/mock_modules.js
@@ -1,3 +1,14 @@
+/**
+ * These are modules that can be used inside of documentation
+ * to provide more enriching examples. The purpose of keeping
+ * these functions in this file is to abstract away unnecessary
+ * implementation details for setting up an example in an effort
+ * to focus more on the component's usage itself.
+ * 
+ * @example using the randomColors in documentation
+ * const randomColors = mockImport('randomColors');
+ * randomColors.get().then(randomColors => // use random colors);
+ */
 const modules = {
   randomColors: (function() {
     const getHex = (num) => num.toString(16).padStart(2, '0');
@@ -35,7 +46,7 @@ const modules = {
 function mockImport(moduleName) {
   const requestedModule = modules[moduleName];
   if (!requestedModule) {
-    throw new Error(`Mock module "${moduleName}" was not found in Playground editor`);
+    throw new Error(`Mock module "${moduleName}" was not found.`);
   }
   return requestedModule;
 }

--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -5,6 +5,11 @@ route: /changelog
 
 # Changelog
 
+## 3.5.0 (pending)
+
+- Added `AInView` component
+- Added `maxHeight` and `onScrollToEnd` props inside of `ADataTable` to determine when a user scrolls through all of the table data
+
 ## 3.4.1 (3-16-2022)
 
 - Fix `useADateRange` minimum and maximum date calculation

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -217,6 +217,10 @@ ADataTable.propTypes = {
    */
   items: PropTypes.arrayOf(PropTypes.object),
   /**
+   * Called when the user reaches the bottom of the data table.
+   */
+  onScrollToEnd: PropTypes.func,
+  /**
    * Handles the `sort` event.
    */
   onSort: PropTypes.func,

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -60,10 +60,7 @@ const ADataTable = forwardRef(
         );
       }
     }
-    if (!headers || !items) {
-      return null;
-    }
-    return (
+    return headers && items && (
       <ADataTableWrapper
         ref={tableWrapperRef}
         shouldWrap={typeof onScrollToEnd === 'function' || maxHeight}
@@ -211,11 +208,11 @@ ADataTable.propTypes = {
         component: PropTypes.func
       })
     })
-  ),
+  ).isRequired,
   /**
    * Sets the table data.
    */
-  items: PropTypes.arrayOf(PropTypes.object),
+  items: PropTypes.arrayOf(PropTypes.object).isRequired,
   /**
    * Called when the user reaches the bottom of the data table.
    */

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -60,129 +60,132 @@ const ADataTable = forwardRef(
         );
       }
     }
+    if (!headers || !items) {
+      return null;
+    }
     return (
-      headers &&
-      items && (
-        <ADataTableWrapper ref={tableWrapperRef} shouldWrap={typeof onScrollToEnd === 'function' || maxHeight} maxHeight={maxHeight}>
-          <ASimpleTable {...rest} ref={ref} className={className}>
-            {headers && (
-              <thead>
-                <tr>
-                  {headers.map((x, i) => {
-                    const headerProps = {
-                      className: `a-data-table__header ${
-                        x.sortable ? "a-data-table__header--sortable" : ""
-                      } text-${x.align || "start"} ${x.className || ""}`
-                        .replace("  ", " ")
-                        .trim(),
-                      role: "columnheader",
-                      scope: "col",
-                      "aria-label": x.name
-                    };
+      <ADataTableWrapper
+        ref={tableWrapperRef}
+        shouldWrap={typeof onScrollToEnd === 'function' || maxHeight}
+        maxHeight={maxHeight}>
+        <ASimpleTable {...rest} ref={ref} className={className}>
+          {headers && (
+            <thead>
+              <tr>
+                {headers.map((x, i) => {
+                  const headerProps = {
+                    className: `a-data-table__header ${
+                      x.sortable ? "a-data-table__header--sortable" : ""
+                    } text-${x.align || "start"} ${x.className || ""}`
+                      .replace("  ", " ")
+                      .trim(),
+                    role: "columnheader",
+                    scope: "col",
+                    "aria-label": x.name
+                  };
 
-                    if (x.sortable) {
-                      if (!sort || x.key !== sort.key) {
-                        headerProps["aria-label"] +=
-                          ": Not sorted. Activate to sort ascending.";
-                        headerProps["aria-sort"] = "none";
-                      } else if (sort && sort.direction === "asc") {
-                        headerProps["aria-label"] +=
-                          ": Sorted ascending. Activate to sort descending.";
-                        headerProps["aria-sort"] = "ascending";
-                      } else {
-                        headerProps["aria-label"] +=
-                          ": Sorted descending. Activate to remove sorting.";
-                        headerProps["aria-sort"] = "descending";
-                      }
-
-                      headerProps.onClick = () => {
-                        onSort &&
-                          onSort(
-                            sort &&
-                              sort.key === x.key &&
-                              sort.direction === "desc"
-                              ? null
-                              : {
-                                  key: x.key,
-                                  direction:
-                                    sort &&
-                                    x.key === sort.key &&
-                                    sort.direction === "asc"
-                                      ? "desc"
-                                      : "asc"
-                                }
-                          );
-                      };
+                  if (x.sortable) {
+                    if (!sort || x.key !== sort.key) {
+                      headerProps["aria-label"] +=
+                        ": Not sorted. Activate to sort ascending.";
+                      headerProps["aria-sort"] = "none";
+                    } else if (sort && sort.direction === "asc") {
+                      headerProps["aria-label"] +=
+                        ": Sorted ascending. Activate to sort descending.";
+                      headerProps["aria-sort"] = "ascending";
+                    } else {
+                      headerProps["aria-label"] +=
+                        ": Sorted descending. Activate to remove sorting.";
+                      headerProps["aria-sort"] = "descending";
                     }
 
-                    return (
-                      <th {...headerProps} key={`a-data-table_header_${i}`}>
-                        {x.align !== "end" ? x.name : ""}
-                        {x.sortable && (
-                          <AIcon
-                            left={x.align === "end"}
-                            right={x.align !== "end"}
-                            className={`a-data-table__header__sort ${
-                              sort && x.key === sort.key
-                                ? "a-data-table__header__sort--active"
-                                : ""
-                            }`}>
-                            {sort &&
-                            x.key === sort.key &&
+                    headerProps.onClick = () => {
+                      onSort &&
+                        onSort(
+                          sort &&
+                            sort.key === x.key &&
                             sort.direction === "desc"
-                              ? "chevron-down"
-                              : "chevron-up"}
-                          </AIcon>
-                        )}
-                        {x.align === "end" ? x.name : ""}
-                      </th>
-                    );
-                  })}
+                            ? null
+                            : {
+                                key: x.key,
+                                direction:
+                                  sort &&
+                                  x.key === sort.key &&
+                                  sort.direction === "asc"
+                                    ? "desc"
+                                    : "asc"
+                              }
+                        );
+                    };
+                  }
+
+                  return (
+                    <th {...headerProps} key={`a-data-table_header_${i}`}>
+                      {x.align !== "end" ? x.name : ""}
+                      {x.sortable && (
+                        <AIcon
+                          left={x.align === "end"}
+                          right={x.align !== "end"}
+                          className={`a-data-table__header__sort ${
+                            sort && x.key === sort.key
+                              ? "a-data-table__header__sort--active"
+                              : ""
+                          }`}>
+                          {sort &&
+                          x.key === sort.key &&
+                          sort.direction === "desc"
+                            ? "chevron-down"
+                            : "chevron-up"}
+                        </AIcon>
+                      )}
+                      {x.align === "end" ? x.name : ""}
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+          )}
+          <tbody>
+            {sortedItems.map((x, i) => {
+              const isLastRow = i == items.length - 1;
+              const isInfiniteScrollTarget = isLastRow && typeof onScrollToEnd === 'function';
+              const key = `a-data-table_row_${i}`;
+              const rowContent = (
+                <tr key={key}>
+                  {headers.map((y, j) => (
+                    <td
+                      key={`a-data-table_cell_${j}`}
+                      className={`text-${y.align || "start"} ${
+                        y.cell?.className || ""
+                      }`.trim()}>
+                      {y.cell && y.cell.component
+                        ? y.cell.component(x)
+                        : x[y.key]}
+                    </td>
+                  ))}
                 </tr>
-              </thead>
-            )}
-            <tbody>
-              {sortedItems.map((x, i) => {
-                const isLastRow = i == items.length - 1;
-                const isInfiniteScrollTarget = isLastRow && typeof onScrollToEnd === 'function';
-                const key = `a-data-table_row_${i}`;
-                const rowContent = (
-                  <tr key={key}>
-                    {headers.map((y, j) => (
-                      <td
-                        key={`a-data-table_cell_${j}`}
-                        className={`text-${y.align || "start"} ${
-                          y.cell?.className || ""
-                        }`.trim()}>
-                        {y.cell && y.cell.component
-                          ? y.cell.component(x)
-                          : x[y.key]}
-                      </td>
-                    ))}
-                  </tr>
-                );
+              );
 
-                if (!isInfiniteScrollTarget) {
-                  return rowContent;
-                }
+              if (!isInfiniteScrollTarget) {
+                return rowContent;
+              }
 
-                return (
-                  <AInView
-                    key={key}
-                    triggerOnce
-                    onChange={({inView, entry}) => {
-                      if (inView) {
-                        onScrollToEnd(entry);
-                      }
-                    }}>
-                    {rowContent}
-                  </AInView>
-                );
-              })}
-            </tbody>
-          </ASimpleTable>
-        </ADataTableWrapper>
-      )
+              return (
+                <AInView
+                  key={key}
+                  triggerOnce
+                  onChange={({inView, entry}) => {
+                    if (inView) {
+                      onScrollToEnd(entry);
+                    }
+                  }}>
+                  {rowContent}
+                </AInView>
+              );
+            })}
+          </tbody>
+        </ASimpleTable>
+      </ADataTableWrapper>
     );
   }
 );

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -11,22 +11,26 @@ import "./ADataTable.scss";
  * for infinite scrolling
  */
 const ADataTableWrapper = React.forwardRef(({ shouldWrap, maxHeight, style, children, ...rest }, ref) => {
-  return shouldWrap ?
-  <div
-    ref={ref}
-    data-testid='table-wrapper'
-    style={{
-      ...style,
-      overflowY: 'scroll',
-      maxHeight,
-    }}
-    {...rest}>
-      {children}
-    </div> :
-    children;
+  if (!shouldWrap) {
+    return children;
+  }
+
+  return (
+      <div
+        ref={ref}
+        data-testid="table-wrapper"
+        style={{
+          ...style,
+          overflowY: "scroll",
+          maxHeight
+        }}
+        {...rest}>
+        {children}
+      </div>
+  );
 });
 
-ADataTableWrapper.displayName = 'ADataTableWrapper'
+ADataTableWrapper.displayName = 'ADataTableWrapper';
 
 const ADataTable = forwardRef(
   ({className: propsClassName, headers, items, maxHeight, onSort, sort, onScrollToEnd, ...rest}, ref) => {
@@ -141,33 +145,9 @@ const ADataTable = forwardRef(
               {sortedItems.map((x, i) => {
                 const isLastRow = i == items.length - 1;
                 const isInfiniteScrollTarget = isLastRow && typeof onScrollToEnd === 'function';
-                return isInfiniteScrollTarget ? (
-                  <AInView
-                    key={`a-data-table_row_${i}`}
-                    root={tableWrapperRef.current}
-                    triggerOnce={true}
-                    onChange={({inView,entry}) => {
-                      if (inView) {
-                        onScrollToEnd(entry);
-                      }
-                    }}
-                  >
-                    <tr>
-                      {headers.map((y, j) => (
-                        <td
-                          key={`a-data-table_cell_${j}`}
-                          className={`text-${y.align || "start"} ${
-                            y.cell?.className || ""
-                          }`.trim()}>
-                          {y.cell && y.cell.component
-                            ? y.cell.component(x)
-                            : x[y.key]}
-                        </td>
-                      ))}
-                    </tr>
-                  </AInView>
-                ) : (
-                  <tr key={`a-data-table_row_${i}`}>
+                const key = `a-data-table_row_${i}`;
+                const rowContent = (
+                  <tr key={key}>
                     {headers.map((y, j) => (
                       <td
                         key={`a-data-table_cell_${j}`}
@@ -180,6 +160,23 @@ const ADataTable = forwardRef(
                       </td>
                     ))}
                   </tr>
+                );
+
+                if (!isInfiniteScrollTarget) {
+                  return rowContent;
+                }
+
+                return (
+                  <AInView
+                    key={key}
+                    triggerOnce
+                    onChange={({inView, entry}) => {
+                      if (inView) {
+                        onScrollToEnd(entry);
+                      }
+                    }}>
+                    {rowContent}
+                  </AInView>
                 );
               })}
             </tbody>

--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -1,17 +1,16 @@
 import PropTypes from "prop-types";
-import React, {forwardRef, useLayoutEffect, useRef} from "react";
+import React, {forwardRef, useRef} from "react";
 
 import AInView from '../AInView';
 import AIcon from "../AIcon";
 import ASimpleTable from "../ASimpleTable";
 import "./ADataTable.scss";
-import { handleMultipleRefs } from "../../utils/helpers";
 
 /**
  * Used inside ADataTable to enable proper styling
  * for infinite scrolling
  */
-const TableWrapper = React.forwardRef(({ shouldWrap, maxHeight, style, children, ...rest }, ref) => {
+const ADataTableWrapper = React.forwardRef(({ shouldWrap, maxHeight, style, children, ...rest }, ref) => {
   return shouldWrap ?
   <div
     ref={ref}
@@ -27,8 +26,10 @@ const TableWrapper = React.forwardRef(({ shouldWrap, maxHeight, style, children,
     children;
 });
 
+ADataTableWrapper.displayName = 'ADataTableWrapper'
+
 const ADataTable = forwardRef(
-  ({className: propsClassName, headers, items, maxHeight, onSort, sort, onScrollToEnd, lastRowRef, ...rest}, ref) => {
+  ({className: propsClassName, headers, items, maxHeight, onSort, sort, onScrollToEnd, ...rest}, ref) => {
     const tableWrapperRef = useRef();
     let className = "a-data-table";
 
@@ -58,7 +59,7 @@ const ADataTable = forwardRef(
     return (
       headers &&
       items && (
-        <TableWrapper ref={tableWrapperRef} shouldWrap={typeof onScrollToEnd === 'function' || maxHeight} maxHeight={maxHeight}>
+        <ADataTableWrapper ref={tableWrapperRef} shouldWrap={typeof onScrollToEnd === 'function' || maxHeight} maxHeight={maxHeight}>
           <ASimpleTable {...rest} ref={ref} className={className}>
             {headers && (
               <thead>
@@ -183,7 +184,7 @@ const ADataTable = forwardRef(
               })}
             </tbody>
           </ASimpleTable>
-        </TableWrapper>
+        </ADataTableWrapper>
       )
     );
   }

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -97,23 +97,29 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
 <Playground
   noInline
   code={`
-  // This is a mock API used to hide pagination implementation details
-  // for this example
+  // This is a mock API used to hide pagination
+  // implementation details for this example
   const randomColors = mockImport('randomColors');
+  
   // Used to cap the table to 125 items. In a real
   // use-case, the API will probably determine if
   // the data is exhausted.
   const MAX_ITEMS = 125;
+  
   // So that we don't block the footer from being accessible,
   // the infinite scrolling should be capped as well
   const INFINITE_SCROLL_MAX = 75;
+  
   const InfiniteScrollDemo = () => {
     const [isLoading, setIsLoading] = useState(true);
-    const [canLoadMore, setCanLoadMore] = useState(false);
+    const [showLoadMore, setShowLoadMore] = useState(false);
     const [items, setItems] = useState([]);
     const addNextItems = (nextItems) => {
       setItems(prevItems => [...prevItems, ...nextItems]);
     }
+    
+    // Initially load the table with
+    // random colors
     useEffect(() => {
       randomColors.get(25).then(colors => {
         addNextItems(colors);
@@ -131,10 +137,15 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
             if (items.length >= MAX_ITEMS) {
               return;
             }
+            
+            // Although the user won't be able to infinitely scroll,
+            // we still want to enable them to fetch more content
             if (items.length >= INFINITE_SCROLL_MAX && items.length < MAX_ITEMS) {
-              setCanLoadMore(true);
+              setShowLoadMore(true);
               return;
             }
+            
+            // Fetch next colors for infinite scrolling functionality
             setIsLoading(true);
             randomColors.get(25).then(nextColors => {
               addNextItems(nextColors);
@@ -165,11 +176,16 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
             }
           ]}
         />
-        {canLoadMore && (
+        {isLoading && (
+          <div style={{display: 'flex', justifyContent: 'center', marginTop: '10px' }}>
+              <ADotLoader />
+          </div>
+        )}
+        {showLoadMore && (
           <div style={{display: 'flex', justifyContent: 'center', marginTop: '10px' }}>
             <AButton
               onClick={() => {
-                setCanLoadMore(false);
+                setShowLoadMore(false);
                 setIsLoading(true);
                 randomColors.get(25).then(nextColors => {
                   addNextItems(nextColors);
@@ -177,11 +193,10 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
                 })
               }}
             >
-            Load More
+              Load More
             </AButton>
           </div>
         )}
-        {isLoading && <ADotLoader />}
       </>
     )
   };
@@ -197,4 +212,4 @@ The `ADataTable` component inherits passed props.
 
 ## Accessibility Notes
 
-When using infinite scroll within the `ADataTable`, it is highly recommended to also render a button to explicitly load more content. This is to enable content underneath the table to be accessible for keyboard users. One possible implementation is to use infinite scroll for items leading up to a certain range, then request that the user explicitly load more items after a certain number of items are infinitely scrolled.
+When using infinite scroll within the `ADataTable`, it is recommended to set a maxinumum infinite scrolling threshold in your implementation so that screen readers and keyboard users can also have a good user experience. To continue loading more content after reaching the target threshold, you can use the "Load More" pattern by rendering a button that will then begin to explicitly load more table content with the user's consent.

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -100,13 +100,23 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
   // This is a mock API used to hide pagination implementation details
   // for this example
   const randomColors = mockImport('randomColors');
-  const MAX_ITEMS = 100;
+  // Used to cap the table to 125 items. In a real
+  // use-case, the API will probably determine if
+  // the data is exhausted.
+  const MAX_ITEMS = 125;
+  // So that we don't block the footer from being accessible,
+  // the infinite scrolling should be capped as well
+  const INFINITE_SCROLL_MAX = 75;
   const InfiniteScrollDemo = () => {
     const [isLoading, setIsLoading] = useState(true);
+    const [canLoadMore, setCanLoadMore] = useState(false);
     const [items, setItems] = useState([]);
+    const addNextItems = (nextItems) => {
+      setItems(prevItems => [...prevItems, ...nextItems]);
+    }
     useEffect(() => {
-      randomColors.get(10).then(colors => {
-        setItems(colors);
+      randomColors.get(25).then(colors => {
+        addNextItems(colors);
         setIsLoading(false);
       });
     }, []);
@@ -116,13 +126,17 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
           striped
           tight
           maxHeight='300px'
-          onScrollToEnd={() => {
+          onScrollToEnd={(entry) => {
             if (items.length >= MAX_ITEMS) {
               return;
             }
+            if (items.length >= INFINITE_SCROLL_MAX && items.length < MAX_ITEMS) {
+              setCanLoadMore(true);
+              return;
+            }
             setIsLoading(true);
-            randomColors.get(10).then(nextColors => {
-              setItems(prevItems => [...prevItems, ...nextColors]);
+            randomColors.get(25).then(nextColors => {
+              addNextItems(nextColors);
               setIsLoading(false);
             });
           }}
@@ -150,6 +164,22 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
             }
           ]}
         />
+        {canLoadMore && (
+          <div style={{display: 'flex', justifyContent: 'center', marginTop: '10px' }}>
+            <AButton
+              onClick={() => {
+                setCanLoadMore(false);
+                setIsLoading(true);
+                randomColors.get(25).then(nextColors => {
+                  addNextItems(nextColors);
+                  setIsLoading(false);
+                })
+              }}
+            >
+            Load More
+            </AButton>
+          </div>
+        )}
         {isLoading && <ADotLoader />}
       </>
     )
@@ -163,3 +193,7 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
 The `ADataTable` component inherits passed props.
 
 <Props of="ADataTable" />
+
+## Accessibility Notes
+
+When using infinite scroll within the `ADataTable`, it is highly recommended to also render a button to explicitly load more content. This is to enable content underneath the table to be accessible for keyboard users. One possible implementation is to use infinite scroll for items leading up to a certain range, then request that the user explicitly load more items after a certain number of items are infinitely scrolled.

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -100,12 +100,12 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
   // This is a mock API used to hide pagination implementation details
   // for this example
   const randomColors = mockImport('randomColors');
-  
+  const MAX_ITEMS = 100;
   const InfiniteScrollDemo = () => {
     const [isLoading, setIsLoading] = useState(true);
     const [items, setItems] = useState([]);
     useEffect(() => {
-      randomColors.get().then(colors => {
+      randomColors.get(10).then(colors => {
         setItems(colors);
         setIsLoading(false);
       });
@@ -113,15 +113,15 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
     return (
       <>
         <ADataTable
-          stripped
+          striped
           tight
           maxHeight='300px'
           onScrollToEnd={() => {
-            if (items.length === 100) {
+            if (items.length >= MAX_ITEMS) {
               return;
             }
             setIsLoading(true);
-            randomColors.get().then(nextColors => {
+            randomColors.get(10).then(nextColors => {
               setItems(prevItems => [...prevItems, ...nextColors]);
               setIsLoading(false);
             });
@@ -155,43 +155,7 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
     )
   };
   render(<InfiniteScrollDemo />);
-  
-  // Mock modules
-  function mockImport(moduleName) {
-    const modules = {
-      randomColors: () => {
-        const getHex = (num) => num.toString(16).padStart(2, '0');
-        const getRandomRgb = () => {
-          const r = Math.floor(Math.random() * 256);
-          const g = Math.floor(Math.random() * 256);
-          const b = Math.floor(Math.random() * 256);
-          return {r, g, b};
-        };
-        const rgbToHex = ({r, g, b}) => {
-          const rHex = getHex(r), gHex = getHex(g), bHex = getHex(b);
-          return '#' + rHex + gHex + bHex;
-        };
-        const generateRandomColors = () => {
-          const empty = [...new Array(25)].fill('');
-          return empty.map(() => {
-            const rgb = getRandomRgb();
-            const hex = rgbToHex(rgb);
-            return {
-              ...rgb,
-              hex,
-            };
-          });
-        };
-        const get = () => {
-          return new Promise((resolve) => {
-            setTimeout(() => resolve(generateRandomColors()), 1000);
-          })
-        };
-        return { get };
-      },
-    };
-    return modules[moduleName]()
-  }`}
+`}
 />
 
 ## Data Table Props

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -126,6 +126,7 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
           striped
           tight
           maxHeight='300px'
+          aria-live="polite"
           onScrollToEnd={(entry) => {
             if (items.length >= MAX_ITEMS) {
               return;

--- a/framework/components/ADataTable/ADataTable.mdx
+++ b/framework/components/ADataTable/ADataTable.mdx
@@ -1,7 +1,7 @@
 ---
 name: Data Tables
 route: /components/data-table
-components: ADataTable
+components: ADataTable, useInfiniteScroll
 ---
 
 # Data Tables
@@ -15,6 +15,8 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
 ```
 
 ## Usage
+
+### Basic
 
 <Playground
   code={`() => {
@@ -88,6 +90,108 @@ import {ADataTable} from "@cisco-sbg-ui/atomic-react";
   );
 }
 `}
+/>
+
+### Infinite Scrolling
+
+<Playground
+  noInline
+  code={`
+  // This is a mock API used to hide pagination implementation details
+  // for this example
+  const randomColors = mockImport('randomColors');
+  
+  const InfiniteScrollDemo = () => {
+    const [isLoading, setIsLoading] = useState(true);
+    const [items, setItems] = useState([]);
+    useEffect(() => {
+      randomColors.get().then(colors => {
+        setItems(colors);
+        setIsLoading(false);
+      });
+    }, []);
+    return (
+      <>
+        <ADataTable
+          stripped
+          tight
+          maxHeight='300px'
+          onScrollToEnd={() => {
+            if (items.length === 100) {
+              return;
+            }
+            setIsLoading(true);
+            randomColors.get().then(nextColors => {
+              setItems(prevItems => [...prevItems, ...nextColors]);
+              setIsLoading(false);
+            });
+          }}
+          items={items}
+          headers={[
+            { name: 'r', key: 'r', },
+            { name: 'g', key: 'g', },
+            { name: 'b', key: 'b', },
+            {
+              name: 'hex',
+              key: 'hex',
+              cell: {
+                component: (rowData) => (
+                  <div style={{display: 'flex', alignItems: 'center'}}>
+                    <div style={{
+                      background: rowData.hex,
+                      width: '25px',
+                      height: '25px',
+                      marginRight: '5px',
+                      }} />
+                    <p>{rowData.hex}</p>
+                  </div>
+                )
+              }
+            }
+          ]}
+        />
+        {isLoading && <ADotLoader />}
+      </>
+    )
+  };
+  render(<InfiniteScrollDemo />);
+  
+  // Mock modules
+  function mockImport(moduleName) {
+    const modules = {
+      randomColors: () => {
+        const getHex = (num) => num.toString(16).padStart(2, '0');
+        const getRandomRgb = () => {
+          const r = Math.floor(Math.random() * 256);
+          const g = Math.floor(Math.random() * 256);
+          const b = Math.floor(Math.random() * 256);
+          return {r, g, b};
+        };
+        const rgbToHex = ({r, g, b}) => {
+          const rHex = getHex(r), gHex = getHex(g), bHex = getHex(b);
+          return '#' + rHex + gHex + bHex;
+        };
+        const generateRandomColors = () => {
+          const empty = [...new Array(25)].fill('');
+          return empty.map(() => {
+            const rgb = getRandomRgb();
+            const hex = rgbToHex(rgb);
+            return {
+              ...rgb,
+              hex,
+            };
+          });
+        };
+        const get = () => {
+          return new Promise((resolve) => {
+            setTimeout(() => resolve(generateRandomColors()), 1000);
+          })
+        };
+        return { get };
+      },
+    };
+    return modules[moduleName]()
+  }`}
 />
 
 ## Data Table Props

--- a/framework/components/ADataTable/ADataTable.spec.js
+++ b/framework/components/ADataTable/ADataTable.spec.js
@@ -4,6 +4,7 @@ context("ADataTable", () => {
   });
 
   const basicUsageSelector = `#basic + .playground`;
+  const infiniteScrollSelector = '#infinite-scrolling + .playground';
 
   it("sorts normally", () => {
     cy.get(`${basicUsageSelector} td`).eq(0).contains(11.1);
@@ -44,6 +45,15 @@ context("ADataTable", () => {
     cy.get(`${basicUsageSelector} td`).eq(2).contains("aardvark");
   });
 
+  it("allows events to be fired when the last row is on the screen", () => {
+    cy.get(`${infiniteScrollSelector} tr`).should("have.length", 26);
+    cy.get(`${infiniteScrollSelector} div[data-testid="table-wrapper"]`).scrollTo('bottom');
+    // Disable this eslint rule since the demo uses an arbitrary delay
+    // to mimic a delay from an HTTP request
+    cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+    cy.get(`${infiniteScrollSelector} tr`).should("have.length", 51);
+  });
+
   it("aligns correctly", () => {
     if (Cypress.env("snapshots") === "off") return;
 
@@ -51,4 +61,5 @@ context("ADataTable", () => {
       "DataTable 1"
     );
   });
+
 });

--- a/framework/components/ADataTable/ADataTable.spec.js
+++ b/framework/components/ADataTable/ADataTable.spec.js
@@ -3,49 +3,51 @@ context("ADataTable", () => {
     cy.visitInLightTheme("http://localhost:3000/components/data-table");
   });
 
+  const basicUsageSelector = `#basic + .playground`;
+
   it("sorts normally", () => {
-    cy.get("#usage + .playground td").eq(0).contains(11.1);
-    cy.get("#usage + .playground th").eq(0).click();
-    cy.get("#usage + .playground td").eq(0).contains(8.9);
-    cy.get("#usage + .playground th").eq(0).click();
-    cy.get("#usage + .playground td").eq(0).contains(11.1);
-    cy.get("#usage + .playground th .a-icon")
+    cy.get(`${basicUsageSelector} td`).eq(0).contains(11.1);
+    cy.get(`${basicUsageSelector} th`).eq(0).click();
+    cy.get(`${basicUsageSelector} td`).eq(0).contains(8.9);
+    cy.get(`${basicUsageSelector} th`).eq(0).click();
+    cy.get(`${basicUsageSelector} td`).eq(0).contains(11.1);
+    cy.get(`${basicUsageSelector} th .a-icon`)
       .eq(0)
       .should("have.attr", "aria-label", "chevron-down icon");
-    cy.get("#usage + .playground th").eq(0).click();
-    cy.get("#usage + .playground td").eq(0).contains(11.1);
+    cy.get(`${basicUsageSelector} th`).eq(0).click();
+    cy.get(`${basicUsageSelector} td`).eq(0).contains(11.1);
   });
 
   it("allows disabled sort", () => {
-    cy.get("#usage + .playground td").eq(1).contains(526);
-    cy.get("#usage + .playground th").eq(1).click();
-    cy.get("#usage + .playground td").eq(1).contains(526);
-    cy.get("#usage + .playground th").eq(1).click();
-    cy.get("#usage + .playground td").eq(1).contains(526);
-    cy.get("#usage + .playground th .a-icon")
+    cy.get(`${basicUsageSelector} td`).eq(1).contains(526);
+    cy.get(`${basicUsageSelector} th`).eq(1).click();
+    cy.get(`${basicUsageSelector} td`).eq(1).contains(526);
+    cy.get(`${basicUsageSelector} th`).eq(1).click();
+    cy.get(`${basicUsageSelector} td`).eq(1).contains(526);
+    cy.get(`${basicUsageSelector} th .a-icon`)
       .eq(1)
       .should("have.attr", "aria-label", "chevron-down icon");
-    cy.get("#usage + .playground th").eq(1).click();
-    cy.get("#usage + .playground td").eq(1).contains(526);
+    cy.get(`${basicUsageSelector} th`).eq(1).click();
+    cy.get(`${basicUsageSelector} td`).eq(1).contains(526);
   });
 
   it("allows custom sort", () => {
-    cy.get("#usage + .playground td").eq(2).contains("aardvark");
-    cy.get("#usage + .playground th").eq(2).click();
-    cy.get("#usage + .playground td").eq(2).contains("aardvark");
-    cy.get("#usage + .playground th").eq(2).click();
-    cy.get("#usage + .playground td").eq(2).contains("Zanzibar");
-    cy.get("#usage + .playground th .a-icon")
+    cy.get(`${basicUsageSelector} td`).eq(2).contains("aardvark");
+    cy.get(`${basicUsageSelector} th`).eq(2).click();
+    cy.get(`${basicUsageSelector} td`).eq(2).contains("aardvark");
+    cy.get(`${basicUsageSelector} th`).eq(2).click();
+    cy.get(`${basicUsageSelector} td`).eq(2).contains("Zanzibar");
+    cy.get(`${basicUsageSelector} th .a-icon`)
       .eq(2)
       .should("have.attr", "aria-label", "chevron-down icon");
-    cy.get("#usage + .playground th").eq(2).click();
-    cy.get("#usage + .playground td").eq(2).contains("aardvark");
+    cy.get(`${basicUsageSelector} th`).eq(2).click();
+    cy.get(`${basicUsageSelector} td`).eq(2).contains("aardvark");
   });
 
   it("aligns correctly", () => {
     if (Cypress.env("snapshots") === "off") return;
 
-    cy.get("#usage + .playground .playground__preview").compareSnapshot(
+    cy.get(`${basicUsageSelector} .playground__preview`).compareSnapshot(
       "DataTable 1"
     );
   });

--- a/framework/components/AInView/AInView.js
+++ b/framework/components/AInView/AInView.js
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types';
+import React from "react";
+import { handleMultipleRefs } from '../../utils/helpers';
+import { useIntersectionObserver } from '../../utils/hooks';
+
+const defaultProps = {
+    onChange: () => {},
+    triggerOnce: false,
+    children: <></>,
+}
+
+/**
+ * Keeps track of a child component's visibility
+ * in the screen. The child component _must_ accept
+ * a forward ref.
+ */
+const AInView = (props = defaultProps) => {
+    const {onChange,triggerOnce,children} = props;
+    const ref = useIntersectionObserver(onChange, {
+        triggerOnce,
+    });
+    return React.cloneElement(children, {
+      ref: handleMultipleRefs(ref, children.ref),
+    });
+};
+
+AInView.propTypes = {
+    /**
+     * Function to be called when the component
+     * switches from entering and exiting the
+     * view
+     */
+    onChange: PropTypes.func,
+    /**
+     * Determines if the `onChange` handler should
+     * only be called on the first initial instance
+     * of the component being in the view
+     */
+    triggerOnce: PropTypes.bool,
+};
+
+export default AInView;

--- a/framework/components/AInView/AInView.js
+++ b/framework/components/AInView/AInView.js
@@ -15,28 +15,65 @@ const defaultProps = {
  * a forward ref.
  */
 const AInView = (props = defaultProps) => {
-    const {onChange,triggerOnce,children} = props;
+    const {onChange,triggerOnce,children, ...observerConfig} = props;
     const ref = useIntersectionObserver(onChange, {
-        triggerOnce,
+      triggerOnce,
+      ...observerConfig,
     });
     return React.cloneElement(children, {
       ref: handleMultipleRefs(ref, children.ref),
     });
 };
 
+function withinValidThreshold(props, propName) {
+    const propValue = props[propName];
+    if (propValue < 0 || propValue > 1) {
+        throw new Error('Invalid prop threshold.')
+    }
+}
+
+AInView.defaultProps = {
+  onChange: null,
+  triggerOnce: false,
+  children: <></>
+};
+
 AInView.propTypes = {
-    /**
-     * Function to be called when the component
-     * switches from entering and exiting the
-     * view
-     */
-    onChange: PropTypes.func,
-    /**
-     * Determines if the `onChange` handler should
-     * only be called on the first initial instance
-     * of the component being in the view
-     */
-    triggerOnce: PropTypes.bool,
+  /**
+   * The function to be called when the component
+   * toggles entering and exiting the view. An object
+   * with an `inView` property is passed.
+   */
+  onChange: PropTypes.func,
+  /**
+   * Determines if the `onChange` handler should
+   * only be called on the first initial instance
+   * of the component being in the view
+   */
+  triggerOnce: PropTypes.bool,
+  /**
+   * The container of the child component rendered
+   * inside of `AInView`. If not passed, it defaults
+   * to the browser viewport (specified as `null`).
+   * The root should almost always be a scrollable
+   * container.
+   */
+  root: PropTypes.object,
+  /**
+   * A bound you can set on the child component passed
+   * to `AInView` as to how many margin pixels the
+   * trigger should be induced.
+   */
+  rootMargin: PropTypes.string,
+  /**
+   * A value between 0 and 1 which indicates what percentage
+   * of the child component should be in the view before
+   * the trigger is induced. A value of `0` will trigger
+   * when the first pixel enters the view, whereas a value
+   * of `1` requires the entire component to be in the view
+   * (assuming no `rootMargin` props are passed as well)
+   */
+  threshold: withinValidThreshold
 };
 
 export default AInView;

--- a/framework/components/AInView/AInView.js
+++ b/framework/components/AInView/AInView.js
@@ -3,18 +3,12 @@ import React from "react";
 import { handleMultipleRefs } from '../../utils/helpers';
 import { useIntersectionObserver } from '../../utils/hooks';
 
-const defaultProps = {
-    onChange: () => {},
-    triggerOnce: false,
-    children: <></>,
-}
-
 /**
  * Keeps track of a child component's visibility
  * in the screen. The child component _must_ accept
  * a forward ref.
  */
-const AInView = (props = defaultProps) => {
+const AInView = (props) => {
     const {onChange,triggerOnce,children, ...observerConfig} = props;
     const ref = useIntersectionObserver(onChange, {
       triggerOnce,

--- a/framework/components/AInView/AInView.mdx
+++ b/framework/components/AInView/AInView.mdx
@@ -1,0 +1,209 @@
+---
+name: InView
+route: /components/inview
+components: AInView
+---
+
+# In View
+
+## Install
+
+Integrate with your build to [auto-import](/#integrating), or add an import in your component:
+
+```
+import {AInView} from "@cisco-sbg-ui/atomic-react";
+```
+
+## Usage
+
+### Basic
+
+<Playground
+    code={`() => {
+        // The container of the AInView component ...
+        // ... should almost always be scrollable
+        const containerStyling = {
+            position: 'relative',
+            maxHeight: '300px',
+            overflowY: 'scroll',
+        };
+        const bannerStyling = {
+            position: 'sticky',
+            top: '10px',
+        };
+        const [onScreen, setOnScreen] = useState(false);
+        const scrollContainer = useRef();
+        return (
+            <div>
+                <div style={bannerStyling} aria-live>
+                    Status: {onScreen ? 'On Screen' : 'Off Screen'}<AIcon right={true} size="small">{onScreen ? 'checkmark' : 'close'}</AIcon>
+                    <ADivider />
+                </div>
+                <div ref={scrollContainer} style={containerStyling}>
+                    <div style={{height: '500px'}}>
+                        <AInView
+                            root={scrollContainer.current}
+                            onChange={({ inView }) => setOnScreen(inView)}
+                        >
+                            <p>Observed Element</p>
+                        </AInView>
+                    </div>
+                </div>
+            </div>
+        )
+    }`}
+/>
+
+### Asynchronous Actions
+
+<Playground
+  code={`() => {
+  const [status, setStatus] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const wait = (t = 1000) =>
+    new Promise((resolve) => setTimeout(() => resolve('Success'), t));
+  return (
+    <div style={{overflowY: 'scroll', maxHeight: '300px'}}>
+        <div style={{position: 'relative'}}>
+            <p>Scroll down to lazyily call an asychronous function when the card enters the view.</p>
+            <ADivider role="presentation" style={{height: '500px'}} />
+            <AInView
+                triggerOnce
+                onChange={({ inView }) => {
+                    if (inView) {
+                        setIsLoading(true);
+                        wait().then((status) => {
+                            setIsLoading(false);
+                            setStatus(status);
+                        })
+                    }
+                }}>
+                <APanel>
+                    <APanelHeader>
+                        <APanelTitle>Status Check</APanelTitle>
+                    </APanelHeader>
+                    <APanelBody>
+                        <div aria-live="polite">
+                            {isLoading ? <ADotLoader size="small" /> : <p>{status}</p>}
+                        </div>
+                    </APanelBody>
+                </APanel>
+            </AInView>
+        </div>
+    </div>
+  );
+}
+`}
+/>
+
+### Infinite Scrolling
+
+<Playground
+    code={`() => {
+        const createNextItems = () => [...new Array(15)].fill('Item');
+        const [items, setItems] = useState(createNextItems());
+        const [isLoading, setIsLoading] = useState(false);
+        // Helper function to mock an async request
+        const wait = (t = 1000) => new Promise((resolve) =>
+            setTimeout(() => resolve(createNextItems()), t));
+        // Fetches items and sets inner component state
+        const getNextItems = () => {
+            setIsLoading(true);
+            wait().then((nextItems) => {
+                setItems(prevItems => [...prevItems, ...nextItems]);
+                setIsLoading(false);
+            });
+        };
+        // If the list is not exhausted and the ...
+        // ... last item is in view, fetch next batch
+        const handleViewChange = ({ inView }) => {
+            if (inView && items.length <= 50) {
+                getNextItems();
+            }
+        };
+        return (
+            <>
+                <ul style={{maxHeight: '250px', overflowY: 'scroll', }}>
+                    {items.map((text, i) => {
+                        const isLast = i === items.length - 1;
+                        return isLast ? (
+                            <AInView
+                                key={i}
+                                triggerOnce
+                                onChange={handleViewChange}>
+                                <li>
+                                    {text} #{i}
+                                </li>
+                            </AInView>
+                        ) : <li key={i}>{text} #{i}</li>;
+                    })}
+                </ul>
+                {isLoading && items.length < 50 && <ADotLoader size="small" />}
+            </>
+        )
+    }`}
+/>
+
+### Optimistic Infinite Scrolling
+
+In the following example, a margin is specified to indicate that the trigger can run when the observed element is within 200 pixels of the container's viewport, i.e., the `<ul>` element.
+
+<Playground
+    code={`() => {
+        const createNextItems = () => [...new Array(15)].fill('Item');
+        const scrollContainer = useRef();
+        const [items, setItems] = useState(createNextItems());
+        const [isLoading, setIsLoading] = useState(false);
+        // Helper function to mock an async request
+        const wait = (t = 1000) => new Promise((resolve) =>
+            setTimeout(() => resolve(createNextItems()), t));
+        // Fetches items and sets inner component state
+        const getNextItems = () => {
+            setIsLoading(true);
+            wait().then((nextItems) => {
+                setItems(prevItems => [...prevItems, ...nextItems]);
+                setIsLoading(false);
+            });
+        };
+        // If the list is not exhausted and the ...
+        // ... last item is in view, fetch next batch
+        const handleViewChange = ({ inView }) => {
+            if (inView && items.length <= 50) {
+                getNextItems();
+            }
+        };
+        return (
+            <>
+                <ul ref={scrollContainer} style={{maxHeight: '250px', overflowY: 'scroll', }}>
+                    {items.map((text, i) => {
+                        const isLast = i === items.length - 1;
+                        return isLast ? (
+                            <AInView
+                                key={i}
+                                triggerOnce
+                                onChange={handleViewChange}
+                                rootMargin="200px"
+                                root={scrollContainer.current}>
+                                <li>
+                                    {text} #{i}
+                                </li>
+                            </AInView>
+                        ) : <li key={i}>{text} #{i}</li>;
+                    })}
+                </ul>
+                {isLoading && <ADotLoader size="small" />}
+            </>
+        )
+    }`}
+/>
+
+
+## In View Props
+
+The `AInView` component inherits passed props.
+
+<Props of="AInView" />
+
+## Accessibility Notes
+
+If the content inside of `AInView` will change due to a change in the child component's view status, it is suggested to add an `aria-live` attribute onto your child component to indicate to screen readers that content is dynamically changing.

--- a/framework/components/AInView/AInView.mdx
+++ b/framework/components/AInView/AInView.mdx
@@ -39,7 +39,7 @@ import {AInView} from "@cisco-sbg-ui/atomic-react";
                     Status: {onScreen ? 'On Screen' : 'Off Screen'}<AIcon right={true} size="small">{onScreen ? 'checkmark' : 'close'}</AIcon>
                     <ADivider />
                 </div>
-                <div ref={scrollContainer} style={containerStyling}>
+                <div ref={scrollContainer} style={containerStyling} data-testid="scroll-container">
                     <div style={{height: '500px'}}>
                         <AInView
                             root={scrollContainer.current}
@@ -63,7 +63,7 @@ import {AInView} from "@cisco-sbg-ui/atomic-react";
   const wait = (t = 1000) =>
     new Promise((resolve) => setTimeout(() => resolve('Success'), t));
   return (
-    <div style={{overflowY: 'scroll', maxHeight: '300px'}}>
+    <div style={{overflowY: 'scroll', maxHeight: '300px'}} data-testid="scroll-container">
         <div style={{position: 'relative'}}>
             <p>Scroll down to lazyily call an asychronous function when the card enters the view.</p>
             <ADivider role="presentation" style={{height: '500px'}} />

--- a/framework/components/AInView/AInView.spec.js
+++ b/framework/components/AInView/AInView.spec.js
@@ -1,0 +1,31 @@
+context("AInView", () => {
+    before(() => {
+        cy.visitInLightTheme("http://localhost:3000/components/inview");
+    });
+
+    const basicUsageSelector = "#basic + .playground";
+    const asyncUsageSelector = "#asynchronous-actions + .playground";
+    
+    it("should alert when an observed element toggles from being in and out of the view", () => {
+        cy.get(`${basicUsageSelector}`).get(`${basicUsageSelector} *[aria-live]`).contains("On Screen");
+        cy.get(`${basicUsageSelector} *[data-testid="scroll-container"]`).scrollTo("bottom");
+        cy.get(`${basicUsageSelector}`).get(`${basicUsageSelector} *[aria-live]`).contains("Off Screen");
+    });
+
+    it("should allow the toggler callback to run only once after first being in the view", () => {
+        cy.get(`${asyncUsageSelector}`).scrollIntoView();
+        cy.get(`${asyncUsageSelector} *[role="progressbar"]`).should("not.exist");
+        cy.get(`${asyncUsageSelector} *[data-testid="scroll-container"]`).scrollTo("bottom");
+        cy.get(`${asyncUsageSelector} *[role="progressbar"]`).should("be.visible");
+        // Disable this eslint rule since the demo uses an arbitrary delay
+        // to mimic a delay from an HTTP request
+        cy.wait(1000); // eslint-disable-line cypress/no-unnecessary-waiting
+        cy.get(`${asyncUsageSelector} *[aria-live]`).contains("Success");
+
+        // Scroll back to top and test if the async action will only trigger once
+        cy.get(`${asyncUsageSelector} *[data-testid="scroll-container"]`).scrollTo("top");
+        cy.get(`${asyncUsageSelector} *[data-testid="scroll-container"]`).scrollTo("bottom");
+        cy.get(`${asyncUsageSelector} div[role="progressbar"]`).should("not.exist");
+        cy.get(`${asyncUsageSelector} *[aria-live]`).contains("Success");
+    });
+});

--- a/framework/components/AInView/index.js
+++ b/framework/components/AInView/index.js
@@ -1,0 +1,3 @@
+import AInView from './AInView';
+
+export default AInView;

--- a/framework/components/AInView/index.js
+++ b/framework/components/AInView/index.js
@@ -1,3 +1,1 @@
-import AInView from './AInView';
-
-export default AInView;
+export {default} from './AInView';

--- a/framework/index.js
+++ b/framework/index.js
@@ -31,6 +31,7 @@ import {
 } from "./components/AHeader";
 import AHint from "./components/AHint";
 import AIcon from "./components/AIcon";
+import AInView from "./components/AInView";
 import AInputBase from "./components/AInputBase";
 import {AContainer, ARow, ACol, ASpacer} from "./components/ALayout";
 import {
@@ -116,6 +117,7 @@ export {
   AHeaderNavigation,
   AHint,
   AIcon,
+  AInView,
   AInputBase,
   AList,
   AListItem,

--- a/framework/utils/helpers.js
+++ b/framework/utils/helpers.js
@@ -10,15 +10,26 @@ export const getRoundedBoundedClientRect = (el) => {
   };
 };
 
+/**
+ * The `ref` prop in React takes either an
+ * instance of a React Ref (which returns a
+ * mutable object), or a callback function,
+ * but _not_ both. This utility makes it possible
+ * to pass _both_ types of `ref` values by
+ * delegating the incoming DOM node each type of
+ * `ref` values.
+ * @example using two separate refs
+ * <input ref={handleMultipleRefs(someRefCallback, someRefInstance)} />
+ */
 export const handleMultipleRefs = (...refs) => {
-  const callbackRef = (incomingRef) => {
+  const callbackRef = (node) => {
     refs.forEach((ref) => {
+      if (!ref) return;
       if (typeof ref === "function") {
-        ref(incomingRef);
+        ref(node);
         return;
       }
-
-      ref.current = incomingRef;
+      ref.current = node;
     });
   };
   return callbackRef;

--- a/framework/utils/helpers.js
+++ b/framework/utils/helpers.js
@@ -10,6 +10,20 @@ export const getRoundedBoundedClientRect = (el) => {
   };
 };
 
+export const handleMultipleRefs = (...refs) => {
+  const callbackRef = (incomingRef) => {
+    refs.forEach((ref) => {
+      if (typeof ref === "function") {
+        ref(incomingRef);
+        return;
+      }
+
+      ref.current = incomingRef;
+    });
+  };
+  return callbackRef;
+};
+
 // KeyboardEvent.keyCode aliases
 export const keyCodes = Object.freeze({
   enter: 13,

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -65,7 +65,7 @@ export const useIntersectionObserver = (cb, config = defaultConfig) => {
       ...opts,
       threshold: validatedThreshold
     };
-  }, [opts]);
+  }, [opts, validatedThreshold]);
   const intersectionCount = useRef(0);
   const targetRef = useRef();
   const observerRef = useRef();

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -80,7 +80,7 @@ export const useIntersectionObserver = (cb, config = defaultConfig) => {
       intersectionCount.current += 1;
     }
     if (typeof cb === "function") {
-      cb({inView: entry.isIntersecting});
+      cb({inView: entry.isIntersecting, entry, });
     }
   };
 
@@ -118,6 +118,26 @@ export const useIntersectionObserver = (cb, config = defaultConfig) => {
   };
 
   return callbackRef;
+};
+
+/**
+ * An implementation of the useIntersectionObserver
+ * that is pre-configured for infinite scrolling in
+ * a list.
+ */
+export const useInfiniteScroll = (config) => {
+  const {onScroll, ...observerConfig} = config;
+  const scrollTriggerRef = useIntersectionObserver(({inView,entry}) => {
+    if (!inView) {
+      return;
+    }
+    onScroll(entry);
+  }, {
+    triggerOnce: true,
+    ...observerConfig,
+  });
+
+  return scrollTriggerRef;
 };
 
 export const useIsomorphicLayoutEffect =

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -18,23 +18,6 @@ export const useCombinedRefs = (...refs) => {
   return targetRef;
 };
 
-/**
- * Keeps count within a component without
- * causing re-renders. Helpful for internal
- * logic that does not require an update to
- * state.
- */
-export const useCount = (initialCount = 0) => {
-  const count = useRef(initialCount);
-  return {
-    getCount: () => count.current,
-    setCount: (num) => (count.current = num),
-    increment: () => (count.current += 1),
-    decrement: () => (count.current -= 1),
-    resetCount: () => (count.current = 0)
-  };
-};
-
 const isValidThreshold = (threshold) => {
   if (!threshold || threshold < 1 && threshold > 0) {
     return true;

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -120,26 +120,6 @@ export const useIntersectionObserver = (cb, config = defaultConfig) => {
   return callbackRef;
 };
 
-/**
- * An implementation of the useIntersectionObserver
- * that is pre-configured for infinite scrolling in
- * a list.
- */
-export const useInfiniteScroll = (config) => {
-  const {onScroll, ...observerConfig} = config;
-  const scrollTriggerRef = useIntersectionObserver(({inView,entry}) => {
-    if (!inView) {
-      return;
-    }
-    onScroll(entry);
-  }, {
-    triggerOnce: true,
-    ...observerConfig,
-  });
-
-  return scrollTriggerRef;
-};
-
 export const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
@@ -180,70 +160,4 @@ export const useMediaQuery = (config) => {
     matches,
     mediaQueryList: mediaQueryList.current
   };
-};
-
-/**
- * Tracks the presence of a DOM node
- * given configuration options supplied
- * to an Intersection Observer
- * @see https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/IntersectionObserver#parameters
- */
-export const useOnScreen = (config) => {
-  const {cache, onEnter, onExit, ...observerConfig} = config;
-  const o = useRef();
-  const intersectionCount = useCount();
-  const [isOnScreen, setIsOnScreen] = useState(
-    intersectionCount.getCount() > 0
-  );
-
-  const handleIntersection = (entry) => {
-    intersectionCount.increment();
-    setIsOnScreen(true);
-    if (typeof onEnter === "function") {
-      onEnter(entry);
-    }
-  };
-
-  const handleTargetExit = (entry) => {
-    setIsOnScreen(false);
-    if (typeof onExit === "function") {
-      onExit(entry);
-    }
-  };
-
-  const observer = useIntersectionObserver(
-    ([entry]) => {
-      const {isIntersecting, target} = entry;
-      const hasIntersectedOnce = intersectionCount.getCount() > 0;
-      if (cache && hasIntersectedOnce) {
-        observer.unobserve(target);
-        return;
-      }
-
-      isIntersecting ? handleIntersection(entry) : handleTargetExit(entry);
-    },
-    {...observerConfig}
-  );
-
-  const callbackRef = (incomingRef) => {
-    if (!incomingRef) {
-      observer.unobserve(o.current);
-      return;
-    }
-
-    o.current = incomingRef;
-    observer.observe(incomingRef);
-  };
-
-  const targetProps = {
-    ref: callbackRef
-  };
-
-  const target = {
-    onScreenCount: intersectionCount.getCount(),
-    isOnScreen,
-    getTargetProps: () => targetProps
-  };
-
-  return target;
 };

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -89,8 +89,6 @@ export const useIntersectionObserver = (cb, config = defaultConfig) => {
       observerRef.current.unobserve(targetRef.current);
       observerRef.current.disconnect();
     }
-
-    console.log('creating with new: ', opts);
     observerRef.current = new IntersectionObserver(handleChange, observerConfig);
   };
 
@@ -99,7 +97,6 @@ export const useIntersectionObserver = (cb, config = defaultConfig) => {
       intersectionCount.current = 0;
     }
     targetRef.current = node;
-    console.log("creating with new: ", opts);
     observerRef.current = new IntersectionObserver(handleChange, observerConfig);
     observerRef.current.observe(node);
   };

--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -18,6 +18,23 @@ export const useCombinedRefs = (...refs) => {
   return targetRef;
 };
 
+/**
+ * Keeps count within a component without
+ * causing re-renders. Helpful for internal
+ * logic that does not require an update to
+ * state.
+ */
+export const useCount = (initialCount = 0) => {
+  const count = useRef(initialCount);
+  return {
+    getCount: () => count.current,
+    setCount: (num) => (count.current = num),
+    increment: () => (count.current += 1),
+    decrement: () => (count.current -= 1),
+    resetCount: () => (count.current = 0)
+  };
+};
+
 export const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect;
 
@@ -29,31 +46,33 @@ export const useIsomorphicLayoutEffect =
  * query matches the document
  * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/matchMedia
  */
- export const useMediaQuery = (config) => {
-   const { mediaQuery, onChange } = config;
+export const useMediaQuery = (config) => {
+  const {mediaQuery, onChange} = config;
   const mediaQueryList = useRef();
-  const [matches, setMatches] = useState(typeof window !== "undefined" && window?.matchMedia(mediaQuery)?.matches);
+  const [matches, setMatches] = useState(
+    typeof window !== "undefined" && window?.matchMedia(mediaQuery)?.matches
+  );
 
-  const validateQuery = useCallback((e) => {
-      if (typeof onChange === 'function') {
-          onChange(e);
+  const validateQuery = useCallback(
+    (e) => {
+      if (typeof onChange === "function") {
+        onChange(e);
       }
       setMatches(e?.target?.matches);
-  }, [
-      onChange,
-      setMatches
-  ]);
+    },
+    [onChange, setMatches]
+  );
 
   useEffect(() => {
-      mediaQueryList.current = window.matchMedia(mediaQuery);
-      setMatches(mediaQueryList.current.matches);
-      mediaQueryList.current.onchange = validateQuery;
+    mediaQueryList.current = window.matchMedia(mediaQuery);
+    setMatches(mediaQueryList.current.matches);
+    mediaQueryList.current.onchange = validateQuery;
 
-      return () => mediaQueryList.current.onchange = null;
+    return () => (mediaQueryList.current.onchange = null);
   }, [mediaQuery, validateQuery]);
 
   return {
     matches,
-    mediaQueryList: mediaQueryList.current,
+    mediaQueryList: mediaQueryList.current
   };
 };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [x] The changes are documented in component docs and changelog
- [x] The ESLint plugin has been updated if a new component is added
- [x] Test have been added or modified, if appropriate
- [x] Has been verified locally

**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->

* Introduces a new `AInView` component that determines if its child component is currently visible within a specified scrollable container (such as the browser viewport itself, or an element with `overflow: scroll` styling).
* Adds two props to `ADataTable`, which would enable infinite scrolling capabilities:
  * `onScrollToEnd: ({ inView, entry } : { inView: boolean, entry: IntersectionObserverEntry }) => void` - called when the user reaches the end of a data table's length
  * `maxHeight: string` - sets the maximum height of the data table to enable an overflow scroll

**What is the current behavior?** <!--(You can also link to an open issue here)-->

The `ADataTable` does not have functionality to support infinite scrolling.

**What is the new behavior (if this is a feature change)?**

Leverages the [Intersection Observer API]() in order to determine when the last row in the table is being viewed, which enables an external consumer of Atomic React to run a function that would (hypothetically) call the next batch of data table.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No

**Other Information**

* Associated PR for [eslint-config-atomic-react](https://github.com/cisco-sbg-ui/eslint-config-atomic-react)
* Please see [accessibility notes](https://atomic-react-19s81j0dz-securex.vercel.app/components/data-table#accessibility-notes) for infinite scrolling inside of a data table
* Also adds a new hook for using an [intersection observer](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API) in React
* Creates a way to enrich documentation examples without cluttering up the live code editor as seen on [Atomic React](https://atomic-react-19s81j0dz-securex.vercel.app/components/data-table#infinite-scrolling) component usage docs
* This work was initiated from [secure-client-forms](https://github.com/advthreat/secure-client-forms/issues/638)
