### PR TITLE
fix: Pagination pages incorrect when total=[7..11]

### DIFF
--- a/framework/components/APagination/APagination.js
+++ b/framework/components/APagination/APagination.js
@@ -207,7 +207,6 @@ const APagination = forwardRef(
           start = 1;
         } else {
           startPages = Array.from(Array(START_END_LENGTH), (_, x) => x + 1);
-          start = page - PADDING;
         }
 
         if (total - PADDING - START_END_LENGTH <= page) {
@@ -217,7 +216,6 @@ const APagination = forwardRef(
             Array(START_END_LENGTH),
             (_, x) => total - x
           ).reverse();
-          end = page + PADDING;
         }
 
         const midPages = Array.from(

--- a/framework/components/APagination/APagination.js
+++ b/framework/components/APagination/APagination.js
@@ -188,20 +188,42 @@ const APagination = forwardRef(
       }
 
       if (total) {
-        const startPages = page > 6 ? [1, 2, 3] : [];
-        const midPages = [4, 5, 6].includes(page)
-          ? Array.from(Array(page + 2), (_, x) => x + 1).filter(
-              (x) => x > 0 && x <= total
-            )
-          : [total - 3, total - 4, total - 5].includes(page)
-          ? Array.from(
-              Array(total - (page - 3)),
-              (_, x) => page - 2 + x
-            ).filter((x) => x > 0 && x <= total)
-          : Array.from(Array(5), (_, x) => page - 2 + x).filter(
-              (x) => x > 0 && x <= total
-            );
-        const endPages = page < total - 5 ? [total - 2, total - 1, total] : [];
+        // PADDING is what to show around the current page.
+        // If on page 50 of 100 pages, show 48, 49, 50, 51, 52
+        const PADDING = 2;
+
+        // START_END_LENGTH is how much of the beginning to show
+        // If you're on page 50 of 100, show 1, 2, 3 in the start section
+        // and 98, 99, 100 in the end section.
+        const START_END_LENGTH = 1 + PADDING;
+
+        let start = page - PADDING;
+        let end = page + PADDING;
+
+        let startPages = [];
+        let endPages = [];
+
+        if (page <= 1 + PADDING + START_END_LENGTH) {
+          start = 1;
+        } else {
+          startPages = Array.from(Array(START_END_LENGTH), (_, x) => x + 1);
+          start = page - PADDING;
+        }
+
+        if (total - PADDING - START_END_LENGTH <= page) {
+          end = total;
+        } else {
+          endPages = Array.from(
+            Array(START_END_LENGTH),
+            (_, x) => total - x
+          ).reverse();
+          end = page + PADDING;
+        }
+
+        const midPages = Array.from(
+          Array(end - start + 1),
+          (_, x) => x + start
+        );
 
         return (
           <>


### PR DESCRIPTION
Fixes https://github.com/cisco-sbg-ui/atomic-react/issues/1173

**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [x] Test have been added or modified, if appropriate
- [x] Has been verified locally

**What kind of change does this PR introduce?**
Fixes the pagination when total=[7..11]

**What is the current behavior?** <!--(You can also link to an open issue here)-->
See https://github.com/cisco-sbg-ui/atomic-react/issues/1173

<img width="1392" alt="Screen Shot 2022-03-21 at 8 36 24 AM" src="https://user-images.githubusercontent.com/366320/159522576-bf7181b5-1b0c-4f1d-acda-54178a3058bb.png">

**What is the new behavior (if this is a feature change)?**

If the current page is within 5 of the end, the mid section will be extended to the end. Previously this was not happening properly for the "end section".

**Does this PR introduce a breaking change?**
No

**Other information**:

Question: how do I add a test? do I just created a "usage 4" in the pagination section?
