### PR TITLE
fix: use function state setter to prevent frozen ASelect

### DIFF
--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -5,6 +5,10 @@ route: /changelog
 
 # Changelog
 
+## 3.4.2 (3-25-2022)
+
+- Fix `ASelect` from potentially being stuck in a closed state
+
 ## 3.4.1 (3-16-2022)
 
 - Fix `useADateRange` minimum and maximum date calculation

--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -233,10 +233,12 @@ const ASelect = forwardRef(
 
       if (!readOnly) {
         chevronProps.onClick = selectionProps.onClick = () => {
-          setIsOpen(!isOpen);
-          if (!isOpen) {
-            reset();
-          }
+          setIsOpen(prevIsOpen => {
+            if (!prevIsOpen) {
+              reset();
+            }
+            return !prevIsOpen;
+          });
 
           setTimeout(() => {
             const selectedIndex = getSelectedIndex();
@@ -255,7 +257,7 @@ const ASelect = forwardRef(
         selectionProps.onKeyDown = (e) => {
           if ([keyCodes.enter, keyCodes.space].includes(e.keyCode)) {
             e.preventDefault();
-            setIsOpen(!isOpen);
+            setIsOpen(prevIsOpen => !prevIsOpen);
             setTimeout(() => {
               const selectedIndex = getSelectedIndex();
               if (selectedIndex > -1) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cisco-sbg-ui/atomic-react",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "",
   "main": "lib/index.js",
   "module": "lib/index.js",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally

**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->

Possibly resolves an issue related to the `ASelect` dropdown being stuck in a closed state (see [issue #3019](https://github.com/advthreat/GLaDOS/issues/3019)).

**What is the current behavior?** <!--(You can also link to an open issue here)-->

When the icon to open/close the select dropdown is pressed, the new open/close state is being set based off the component's state variable at the top-level.

**What is the new behavior (if this is a feature change)?**

The state setter for opening/closing the dropdown menu uses a callback function to guarantee the previous state of the component.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No

**Other information**:

For more about this pattern, see [functional state updates](https://reactjs.org/docs/hooks-reference.html#functional-updates) in the React docs.
