### PR TITLE
docs: update min and max date picker props example

### DIFF
--- a/framework/components/ADatePicker/ADatePicker.mdx
+++ b/framework/components/ADatePicker/ADatePicker.mdx
@@ -30,14 +30,12 @@ import {ADatePicker} from "@cisco-sbg-ui/atomic-react";
 
 <Playground
   code={`() => {
-  const yesterday = new Date();
-  const today = new Date(2022, 2, 15);
-  const tomorrow = new Date();
-  tomorrow.setDate(today.getDate() + 1);
-  yesterday.setDate(today.getDate() - 1);
-  const [date, setDate] = useState(today);
+  const earliestDay = new Date(2022, 2, 13);
+  const latestDay = new Date(earliestDay);
+  latestDay.setDate(earliestDay.getDate() + 13);
+  const [date, setDate] = useState(earliestDay);
   return (
-    <ADatePicker value={date} onChange={(date) => setDate(date)} minDate={yesterday} maxDate={tomorrow}/>
+    <ADatePicker value={date} onChange={(date) => setDate(date)} minDate={earliestDay} maxDate={latestDay}/>
   );
 }
 `}

--- a/framework/components/ADatePicker/ADatePicker.spec.js
+++ b/framework/components/ADatePicker/ADatePicker.spec.js
@@ -70,7 +70,7 @@ context("ADatePicker", () => {
   const minAndMaxDateSelector = "#with-minimum-and-maximum-dates + .playground .a-date-picker";
 
   it("restricts date day selections", () => {
-    cy.get(`${minAndMaxDateSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 3);
+    cy.get(`${minAndMaxDateSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 14);
   });
 
   const maxDaysSelector = "#date-range-with-maximum-days + .playground .a-date-picker";


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->

Updates the [minimum and maximum](https://atomic-react-8evlhelc4-securex.vercel.app/components/date-picker#with-minimum-and-maximum-dates) date picker props example.


**What is the current behavior?** <!--(You can also link to an open issue here)-->

The example currently does not demo as expected; all the calendar days are disabled.

**What is the new behavior (if this is a feature change)?**

Restructures the logic behind showing a minimum and maximum date in the date picker.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No