### PR TITLE
feat: add props to ASelect to enable dropdown menu styling

### DIFF
--- a/framework/changelog.mdx
+++ b/framework/changelog.mdx
@@ -10,6 +10,7 @@ route: /changelog
 - Fix `ASelect` overflow property when the number of dropdown items exceeds the height of the viewport
 - Added `AInView` component
 - Added `maxHeight` and `onScrollToEnd` props inside of `ADataTable` to determine when a user scrolls through all of the table data
+- Enable styling props for `ASelect` dropdown menu interface
 
 ## 3.4.1 (3-16-2022)
 

--- a/framework/components/ASelect/ASelect.js
+++ b/framework/components/ASelect/ASelect.js
@@ -22,6 +22,8 @@ const ASelect = forwardRef(
     {
       appendContent,
       className: propsClassName,
+      dropdownClassName,
+      dropdownStyle,
       disabled,
       hint,
       itemDisabled = "disabled",
@@ -273,9 +275,14 @@ const ASelect = forwardRef(
       onSelected && onSelected(item);
     };
 
+    let menuClassName = 'a-select__menu-items';
+    if (dropdownClassName) {
+      menuClassName += ` ${dropdownClassName}`;
+    }
+
     const menuComponentProps = {
       anchorRef: inputBaseSurfaceRef,
-      className: "a-select__menu-items",
+      className: menuClassName,
       closeOnClick: false,
       // Menu should not receive focus
       // so that the selected item can
@@ -291,7 +298,8 @@ const ASelect = forwardRef(
         minWidth: "max-content",
         width: inputBaseSurfaceRef?.current?.clientWidth
           ? inputBaseSurfaceRef.current.clientWidth + 2
-          : "auto"
+          : "auto",
+          ...dropdownStyle,
       }
     };
 
@@ -407,6 +415,17 @@ ASelect.propTypes = {
    * Toggles the disabled state.
    */
   disabled: PropTypes.bool,
+  /**
+   * Because ASelect uses an AMenu, the dropdown interface
+   * is mounted outside of the application area. To style
+   * this portion of ASelect, a class can be provided.
+   */
+  dropdownClassName: PropTypes.string,
+  /**
+   * Similar to the dropdownClassName prop, this can be used
+   * to pass a style object to the dropdown interface
+   */
+  dropdownStyle: PropTypes.object,
   /**
    * Sets the hint content.
    */

--- a/framework/components/ASelect/ASelect.mdx
+++ b/framework/components/ASelect/ASelect.mdx
@@ -255,6 +255,7 @@ The `ASelect` component inherits passed props.
   const {isDark} = useATheme();
   return (
     <ASelect
+      dropdownClassName="custom-dropdown-class"
       itemTemplate={({className, index, item, onClick, ...rest}) => (
           <AListItem {...rest} twoLine className={className + (isDark ? " white--text" : " grey--darken-7--text")} style={{backgroundColor: "transparent"}}>
             <AListItemContent onClick={onClick}>

--- a/framework/components/ASelect/ASelect.spec.js
+++ b/framework/components/ASelect/ASelect.spec.js
@@ -38,6 +38,16 @@ context("ASelect", () => {
       .click();
   });
 
+  it("allows a style to be passed to the dropdown user interface", () => {
+    const playground = "#menu-item-templates + .playground";
+    cy.get(`${playground} .a-select__selection`).eq(0).click();
+    cy.get("div[role='listbox']").should(
+      "have.class",
+      "custom-dropdown-class"
+    );
+    cy.get(`${playground} .a-select__selection`).eq(0).click();
+  });
+
   it("opens and closes appropriately", () => {
     cy.get(".a-select__menu-items").should("not.exist");
     cy.get("#usage + .playground .a-select__selection").eq(0).click();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->

Closes #1184


**What is the current behavior?** <!--(You can also link to an open issue here)-->

It is not possible to style the dropdown interface inside of `ASelect`, because `ASelect` uses [`AMenu`](https://atomic-react.security.cisco.com/components/menu) under the hood, which mounts the dropdown interface out of (resaonable) reach with the `className` prop currently being applied to `ASelect`.

**What is the new behavior (if this is a feature change)?**

Passes a class and style object to the dropdown interface to allow for custom styling and disable Atomic React overrides.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No

**Other information**:

I think that the future goal will be adjusting the composability of `ASelect`, and possibly reconsidering it's `AMenu` usage for the sake of accessibly and maintainability. This could look something like:

```jsx
<ASelect className='my-class'>
  <option value='foo'>Foo</option>
  <option value='bar'>Bar</option>
  <option value='baz'>Baz</option>
  {/* so on and so forth */}
</ASelect>
```