### PR TITLE
fix(AInView): include 0 and 1 as valid threshold values

### DIFF
--- a/framework/utils/hooks.js
+++ b/framework/utils/hooks.js
@@ -19,7 +19,10 @@ export const useCombinedRefs = (...refs) => {
 };
 
 const isValidThreshold = (threshold) => {
-  if (!threshold || (threshold < 1 && threshold > 0)) {
+  // A threshold does not have to be passed; the native
+  // Intersection Observer API also takes "null" as a valid
+  // parameter
+  if (!threshold || (threshold <= 1 && threshold >= 0)) {
     return true;
   }
   return false;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->

Fixes an issue where the console would warn if `0` or `1` were passed to the `AInView` component.

**What is the current behavior?** <!--(You can also link to an open issue here)-->

The utility to validate an intersection observer threshold is not including `0` or `1` in its valid values.

**What is the new behavior (if this is a feature change)?**

Update the utility function to return `0` and `1` as valid threshold values.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No