### PR TITLE
docs(ADataTable): clarify onScrollToEnd prop invocation

### DIFF
--- a/framework/components/ADataTable/ADataTable.js
+++ b/framework/components/ADataTable/ADataTable.js
@@ -214,7 +214,7 @@ ADataTable.propTypes = {
    */
   items: PropTypes.arrayOf(PropTypes.object).isRequired,
   /**
-   * Called when the user reaches the bottom of the data table.
+   * Called when the user reaches the bottom of the data table for the first time.
    */
   onScrollToEnd: PropTypes.func,
   /**


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->

Documents the behavior of the `onScrollToEnd` prop inside `ADataTable`.

**What is the current behavior?** <!--(You can also link to an open issue here)-->

The docs do not mention that `onScrollToEnd` is called only for the initial scroll to the bottom of the table.

**What is the new behavior (if this is a feature change)?**

Clarifies that `onScrollToEnd` only fires when the user first reaches the bottom of the table.

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No