### PR TITLE
feat: return state setter to control date range hook state

### DIFF
--- a/framework/components/ADatePicker/ADatePicker.mdx
+++ b/framework/components/ADatePicker/ADatePicker.mdx
@@ -35,7 +35,11 @@ import {ADatePicker} from "@cisco-sbg-ui/atomic-react";
   latestDay.setDate(earliestDay.getDate() + 13);
   const [date, setDate] = useState(earliestDay);
   return (
-    <ADatePicker value={date} onChange={(date) => setDate(date)} minDate={earliestDay} maxDate={latestDay}/>
+    <ADatePicker
+      value={date}
+      onChange={(date) => setDate(date)}
+      minDate={earliestDay}
+      maxDate={latestDay}/>
   );
 }
 `}
@@ -43,11 +47,38 @@ import {ADatePicker} from "@cisco-sbg-ui/atomic-react";
 
 ## Date Range
 
+For date ranges, pass an array indicating the two dates to be selected. `ADatePicker` will determine which come first or second relative to the range itself.
+
 <Playground
   code={`() => {
-  const { value, onChange, } = useADateRange();
+    const [value, setValue] = useState([]);
+    const getNextRange = (nextDate) => {
+      setValue(prevRange => {
+        const isFull = prevRange.length === 2;
+        return isFull ?
+          [nextDate] :
+          prevRange.concat(nextDate);
+      })
+    }
+    return (
+      <>
+        <ADatePicker value={value} onChange={getNextRange} />
+        <AButton className='mt-2' onClick={() => setValue([])}>Clear</AButton>
+      </>
+    )
+  }`}
+/>
+
+To prevent having to duplicate date range sequencing logic across your application (like in the previous example), you can leverage `useADateRange`, which will return the props to pass to `ADatePicker`.
+
+<Playground
+  code={`() => {
+  const { value, onChange, setValue, } = useADateRange();
   return (
-    <ADatePicker value={value} onChange={onChange} />
+      <>
+        <ADatePicker value={value} onChange={onChange} />
+        <AButton className='mt-2' onClick={() => setValue([])}>Clear</AButton>
+      </>
   );
 }
 `}
@@ -57,16 +88,15 @@ import {ADatePicker} from "@cisco-sbg-ui/atomic-react";
 
 <Playground
   code={`() => {
-  const { value, onChange, } = useADateRange([new Date(2022, 2, 28), new Date(2022, 3, 5)]);
-  const [firstSelection, secondSelection] = value;
-  // You can destructure the values from useADateRange to use ...
-  // ... the date picker's range value in your component
+  const { value, onChange, setValue, } = useADateRange([new Date(2022, 2, 28), new Date(2022, 3, 5)]);
+  const [start, end] = value;
   return (
     <>
       <ADatePicker value={value} onChange={onChange} />
         <p aria-live="polite">
-          Selected range: <i>{firstSelection && firstSelection.toLocaleDateString()} - {secondSelection && secondSelection.toLocaleDateString()}</i>
+          Selected range: <i>{start && start.toLocaleDateString()} - {end && end.toLocaleDateString()}</i>
         </p>
+        <AButton onClick={() => setValue([])}>Clear</AButton>
     </>
   );
 }
@@ -74,20 +104,25 @@ import {ADatePicker} from "@cisco-sbg-ui/atomic-react";
 />
 
 ### Date Range with Maximum Days
+
+To limit the length of an arbitrary range to a certain number of days, configure `useADateRange` with a `maxDays` option. Be sure to pass the `minDate` and `maxDate` props to `ADatePicker`.
+
 <Playground
   code={`() => {
-  const { value, ...datePickerProps } = useADateRange({
+  const {value, onChange, minDate, maxDate} = useADateRange({
     initialRange: [new Date(2022, 2, 14), new Date(2022, 2, 16)],
     maxDays: 3
   });
-  const [firstSelection, secondSelection] = value;
-  // Alternatively, you can spread out the remaining values ...
-  // ... to be passed to the date picker
+  const [start, end] = value;
   return (
     <>
-      <ADatePicker value={value} {...datePickerProps} />
+      <ADatePicker
+        value={value}
+        onChange={onChange}
+        minDate={minDate}
+        maxDate={maxDate}/>
       <p aria-live="polite">
-        Selected range: <i>{firstSelection && firstSelection.toLocaleDateString()} - {secondSelection && secondSelection.toLocaleDateString()}</i>
+        Selected range: <i>{start && start.toLocaleDateString()} - {end && end.toLocaleDateString()}</i>
       </p>
     </>
   );

--- a/framework/components/ADatePicker/ADatePicker.spec.js
+++ b/framework/components/ADatePicker/ADatePicker.spec.js
@@ -46,18 +46,25 @@ context("ADatePicker", () => {
   });
 
   it("selects a range between two months", () => {
-    // Pick a month in current calendar selection UI
+    // Pick a day in current month (April)
     cy.get(`${rangeSelector} .a-date-picker__day`).eq(30).click();
 
-    // Navigate to next calendar month, pick a date, and ensure
-    // the range has now been set
+    // Navigate to next calendar month (May) and pick a date
     cy.get(`${rangeSelector} .a-date-picker__next`).click();
     cy.get(`${rangeSelector} .a-date-picker__day`).eq(10).click();
     cy.get(`${rangeSelector} .a-date-picker__day.between:not(.disabled)`).should("have.length", 10);
 
-    // Navigate back to previous month and ensure range is still set
+    // Navigate back to previous month (April) to ensure range is still persisting
     cy.get(`${rangeSelector} .a-date-picker__prev`).click();
     cy.get(`${rangeSelector} .a-date-picker__day.between:not(.disabled)`).should("have.length", 4);
+  });
+
+  it("allows the date range to be controlled", () => {
+    // April has 30 days
+    cy.get("#date-range-with-initial-range + .playground button")
+      .last()
+      .click();
+    cy.get(`${rangeSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 30);
   });
 
   it("displays the upper range bound when an initial range is supplied", () => {
@@ -100,5 +107,4 @@ context("ADatePicker", () => {
     // Two days before and after January 14 should be enabled
     cy.get(`${maxDaysSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 5);    
   });
-
 });

--- a/framework/components/ADatePicker/helpers.js
+++ b/framework/components/ADatePicker/helpers.js
@@ -22,7 +22,7 @@ const isDateTipOfRange = (date, range) => {
 };
 
 const isDateBetweenRange = (date, range) => {
-    const [rangeStartDate, rangeEndDate] = range;
+    const [rangeStartDate, rangeEndDate] = sortDates(range);
     return Date.parse(date) > Date.parse(rangeStartDate) &&
         Date.parse(date) < Date.parse(rangeEndDate);
 };

--- a/framework/components/ADatePicker/useADateRange.js
+++ b/framework/components/ADatePicker/useADateRange.js
@@ -1,29 +1,24 @@
 import { useCallback, useState } from "react";
-import { sortDates } from "./helpers";
 
 /**
- * Sequencing logic for setting an incoming date relative to an existing date range.
- * It has no opinion on if the second selection must be larger than the first selection.
+ * Sequencing logic for adding a new date to a range of
+ * dates.
  * 
- * Flow: first date selection -> second date selection -> first date selection -> second date selection -> (etc.)
- * @param {Array.<Date|null>} oldRange - Tuple with starting date and ending date
+ * Flow: first date selection -> second date selection ->
+ * first date selection -> second date selection -> (etc.)
+ * @param {Array.<Date|null>} existingRange - Tuple with starting date and ending date
  * @param {Date} incomingDate - The next date to sequence
- * @returns tuple the newly set date range
+ * @returns next range sequence
  */
-export const stepSequencer = (existingRange, nextDate) => {
-  const [rangeStartDate, rangeEndDate] = existingRange;
-  const isRangeEmpty = !rangeStartDate && !rangeEndDate;
-  const shouldResetRange = rangeStartDate && rangeEndDate;
-
-  return isRangeEmpty || shouldResetRange ?
-    [nextDate, null] :
-    sortDates([rangeStartDate, nextDate]);
+const rangeSequencer = (existingRange, incomingDate) => {
+  const isFull = existingRange.length === 2;
+  // If range is filled, reset with
+  // a new start date
+  return isFull ?
+    [incomingDate] :
+    existingRange.concat(incomingDate);
 };
 
-/**
- * Hook for storing date range state. Currently uses a step sequence, but has
- * room for flexibility in the future.
- */
 const useADateRange = (config) => {
   // Support older version hook config
   let initialRange;
@@ -53,7 +48,7 @@ const useADateRange = (config) => {
   }
 
   const onChange = useCallback((incomingDate) => {
-    setRange(oldRange => stepSequencer(oldRange, incomingDate));
+    setRange(oldRange => rangeSequencer(oldRange, incomingDate));
   }, [setRange]);
 
   return {

--- a/framework/components/ADatePicker/useADateRange.js
+++ b/framework/components/ADatePicker/useADateRange.js
@@ -53,9 +53,10 @@ const useADateRange = (config) => {
 
   return {
     value: range,
+    setValue: setRange,
     onChange,
     minDate,
-    maxDate,
+    maxDate
   };
 };
 export default useADateRange;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->

Allows a developer to control the state within `useADateRange`.

**What is the current behavior?** <!--(You can also link to an open issue here)-->

The state setter is not returned from `useADateRange`:

```js
return {
  value: range,
  onChange,
  minDate,
  maxDate,
};
```

**What is the new behavior (if this is a feature change)?**

Exposes the setter from `useADateRange` to allow a consumer to control it's state directly:

```js
return {
  value: range,
  // Also return the state setter
  setValue: setRange,
  onChange,
  minDate,
  maxDate,
};
```

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No

**Other information**:

This fix has resulted in #1197 