### PR TITLE
feat(ADatePicker): style date range on hover when choosing an end date

### DIFF
--- a/framework/components/ADatePicker/ADatePicker.scss
+++ b/framework/components/ADatePicker/ADatePicker.scss
@@ -22,7 +22,7 @@ $date-picker-calendar-width: 245px;
 $date-picker-calendar-min-width: 245px;
 $date-picker-calendar-font-size: $font-size--sm;
 $date-picker-calendar-margin: 10px 15px;
-$date-picker-calendar-disabled-opacity: 0.35;
+$date-picker-calendar-disabled-opacity: 0.70;
 $date-picker-day-width: 30px;
 $date-picker-day-padding-top: math.div($base-padding-small-top, 2);
 $date-picker-day-padding-bottom: math.div($base-padding-small-bottom, 2);

--- a/framework/components/ADatePicker/ADatePicker.scss
+++ b/framework/components/ADatePicker/ADatePicker.scss
@@ -64,36 +64,37 @@ $date-picker-day-border-radius: 2px;
   }
 
   &__day {
-    &__label {
+    &__btn {
       color: inherit;
       background-color: transparent;
       &:focus {
         box-shadow: map-deep-get($theme, "base", "box-shadow");
       }
-    }
-
-    &.selected {
-      .a-date-picker__day__label {
+      &:hover:not(:disabled) {
+        background-color: map-deep-get($theme, "base", "color--hover");
+        color: map-deep-get($theme, "base", "inverse-color");
+      }
+      &:disabled {
+        opacity: $date-picker-calendar-disabled-opacity;
+      }
+      &--selected {
         background-color: map-deep-get($theme, "base", "color--selected");
         color: map-deep-get($theme, "base", "inverse-color");
       }
-    }
-
-    &.between {
-      .a-date-picker__day__label {
+      &--highlighted {
         background-color: map-deep-get($theme, "date-picker", "range-bg");
       }
     }
 
     &:hover {
-      .a-date-picker__day__label {
+      .a-date-picker__day__btn:not(:disabled) {
         background-color: map-deep-get($theme, "base", "color--hover");
         color: map-deep-get($theme, "base", "inverse-color");
       }
     }
 
     &:active {
-      .a-date-picker__day__label {
+      .a-date-picker__day__btn:not(:disabled) {
         background-color: map-deep-get($theme, "base", "color--active");
         color: map-deep-get($theme, "base", "inverse-color");
       }
@@ -173,7 +174,7 @@ $date-picker-day-border-radius: 2px;
     min-width: $date-picker-day-width;
     padding-top: $date-picker-day-padding-top;
     padding-bottom: $date-picker-day-padding-bottom;
-    &__label {
+    &__btn {
       border: 0;
       margin: 0;
       padding: 1.2px 0;

--- a/framework/components/ADatePicker/ADatePicker.scss
+++ b/framework/components/ADatePicker/ADatePicker.scss
@@ -79,6 +79,8 @@ $date-picker-day-border-radius: 2px;
       }
       &--selected {
         background-color: map-deep-get($theme, "base", "color--selected");
+      }
+      &--selected:not(&--highlighted) {
         color: map-deep-get($theme, "base", "inverse-color");
       }
       &--highlighted {

--- a/framework/components/ADatePicker/ADatePicker.spec.js
+++ b/framework/components/ADatePicker/ADatePicker.spec.js
@@ -61,6 +61,40 @@ context("ADatePicker", () => {
     cy.get(`${rangeSelector} .a-date-picker__day__btn--highlighted:not(:disabled)`).should("have.length", 4);
   });
 
+  it("persists highlighting of a range between two months", () => {
+    // Select April 26, 2022
+    cy.get(`${rangeSelector} .a-date-picker__day`).eq(30).click();
+
+    // Navigate to next calendar month (May), pick a date, and ensure
+    // the range has now been set
+    cy.get(`${rangeSelector} .a-date-picker__next`).click();
+    cy.get(`${rangeSelector} .a-date-picker__day`).eq(10).click();
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--highlighted:not(:disabled)`).should("have.length", 10);
+
+    // Navigate back to previous month (April) and ensure range is still set
+    cy.get(`${rangeSelector} .a-date-picker__prev`).click();
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--selected`).should("have.length", 1);
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--highlighted:not(:disabled)`).should("have.length", 4);
+
+    // Ensure that the days selected in May that are visible in the April calendar
+    // UI have highlighting to identify they are part of the range
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--highlighted:disabled`).should("have.length", 7);
+  });
+
+  it("highlights the hypothetical range that would be created after choosing the first range date selection when hovering dates", () => {
+    // Select April 26, 2022
+    cy.get(`${rangeSelector} .a-date-picker__day`).eq(30).click();
+
+    // "Hover" April 30, 2022
+    // https://github.com/cypress-io/cypress/issues/10#issuecomment-615947224
+    cy.get(`${rangeSelector} .a-date-picker__day`).eq(34).rightclick();
+
+    // Although April 30, 2022 was not explicity clicked, the hypothetical
+    // range should be styled
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--highlighted`).should("have.length", 3);
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--selected`).should("have.length", 2);
+  });
+
   it("displays the upper range bound when an initial range is supplied", () => {
     // Revisit to reset state of calendar
     cy.visitInLightTheme("http://localhost:3000/components/date-picker");

--- a/framework/components/ADatePicker/ADatePicker.spec.js
+++ b/framework/components/ADatePicker/ADatePicker.spec.js
@@ -10,7 +10,7 @@ context("ADatePicker", () => {
     cy.get("#usage + .playground .a-date-picker").contains("February");
     cy.get("#usage + .playground .a-date-picker__prev").click();
     cy.get("#usage + .playground .a-date-picker").contains("January");
-    cy.get("#usage + .playground .a-date-picker__day.selected").contains("14");
+    cy.get("#usage + .playground .a-date-picker__day__btn--selected").contains("14");
     cy.get("#usage + .playground .a-date-picker__day").eq(7).click();
     cy.get("#usage + .playground .a-date-picker__day").contains("3");
   });
@@ -34,43 +34,44 @@ context("ADatePicker", () => {
   it("selects the two outer bounds of a date range", () => {
     cy.get(`${rangeSelector} .a-date-picker__day`).eq(7).click();
     cy.get(`${rangeSelector} .a-date-picker__day`).eq(10).click();
-    cy.get(`${rangeSelector} .a-date-picker__day.selected`).contains("3");
-    cy.get(`${rangeSelector} .a-date-picker__day.selected`).contains("6");
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--selected`).contains("3");
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--selected`).contains("6");
   });
 
   it("selects inner bounds between a date range", () => {
     cy.get(`${rangeSelector} .a-date-picker__day`).eq(25).click();
     cy.get(`${rangeSelector} .a-date-picker__day`).eq(28).click();
-    cy.get(`${rangeSelector} .a-date-picker__day.between`).eq(0).contains("22");
-    cy.get(`${rangeSelector} .a-date-picker__day.between`).eq(1).contains("23");
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--highlighted`).eq(0).contains("22");
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--highlighted`).eq(1).contains("23");
   });
 
   it("selects a range between two months", () => {
-    // Pick a month in current calendar selection UI
+    // Select April 26, 2022
     cy.get(`${rangeSelector} .a-date-picker__day`).eq(30).click();
 
-    // Navigate to next calendar month, pick a date, and ensure
+    // Navigate to next calendar month (May), pick a date, and ensure
     // the range has now been set
     cy.get(`${rangeSelector} .a-date-picker__next`).click();
     cy.get(`${rangeSelector} .a-date-picker__day`).eq(10).click();
-    cy.get(`${rangeSelector} .a-date-picker__day.between:not(.disabled)`).should("have.length", 10);
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--highlighted:not(:disabled)`).should("have.length", 10);
 
-    // Navigate back to previous month and ensure range is still set
+    // Navigate back to previous month (April) and ensure range is still set
     cy.get(`${rangeSelector} .a-date-picker__prev`).click();
-    cy.get(`${rangeSelector} .a-date-picker__day.between:not(.disabled)`).should("have.length", 4);
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--selected`).should("have.length", 1);
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--highlighted:not(:disabled)`).should("have.length", 4);
   });
 
   it("displays the upper range bound when an initial range is supplied", () => {
     // Revisit to reset state of calendar
     cy.visitInLightTheme("http://localhost:3000/components/date-picker");
     cy.get(rangeSelector).contains("April");
-    cy.get(`${rangeSelector} .a-date-picker__day.selected`).contains("5");
+    cy.get(`${rangeSelector} .a-date-picker__day__btn--selected`).contains("5");
   });
 
   const minAndMaxDateSelector = "#with-minimum-and-maximum-dates + .playground .a-date-picker";
 
   it("restricts date day selections", () => {
-    cy.get(`${minAndMaxDateSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 14);
+    cy.get(`${minAndMaxDateSelector} .a-date-picker__day__btn:not(:disabled)`).should("have.length", 14);
   });
 
   const maxDaysSelector = "#date-range-with-maximum-days + .playground .a-date-picker";
@@ -80,7 +81,7 @@ context("ADatePicker", () => {
     cy.get(`${maxDaysSelector} .a-date-picker__day`).eq(15).click();
 
     // Two days before and after March 14 should be enabled
-    cy.get(`${maxDaysSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 5);
+    cy.get(`${maxDaysSelector} .a-date-picker__day__btn:not(:disabled)`).should("have.length", 5);
   });
 
   it("only allows a maximum number of days to be selected in a range", () => {
@@ -88,7 +89,7 @@ context("ADatePicker", () => {
     cy.get(`${maxDaysSelector} .a-date-picker__day`).eq(17).click();
 
     // All days in March should go back to being selectable
-    cy.get(`${maxDaysSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 31);
+    cy.get(`${maxDaysSelector} .a-date-picker__day__btn:not(:disabled)`).should("have.length", 31);
   });
   
   it("allows a maximum number of days to be selected in previous subsequent months", () => {
@@ -98,7 +99,7 @@ context("ADatePicker", () => {
     cy.get(`${maxDaysSelector} .a-date-picker__day`).eq(20).click();
 
     // Two days before and after January 14 should be enabled
-    cy.get(`${maxDaysSelector} .a-date-picker__day:not(.disabled)`).should("have.length", 5);    
+    cy.get(`${maxDaysSelector} .a-date-picker__day__btn:not(:disabled)`).should("have.length", 5);    
   });
 
 });

--- a/framework/components/ADatePicker/useADateRange.js
+++ b/framework/components/ADatePicker/useADateRange.js
@@ -12,10 +12,10 @@ import { sortDates } from "./helpers";
  */
 export const stepSequencer = (existingRange, nextDate) => {
   const [rangeStartDate, rangeEndDate] = existingRange;
-  const isRangeEmpty = !rangeStartDate && !rangeEndDate;
-  const shouldResetRange = rangeStartDate && rangeEndDate;
+  const isEmpty = !rangeStartDate && !rangeEndDate;
+  const isFull = rangeStartDate && rangeEndDate;
 
-  return isRangeEmpty || shouldResetRange ?
+  return isEmpty || isFull ?
     [nextDate, null] :
     sortDates([rangeStartDate, nextDate]);
 };


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->
Closes #1167 and adds styling for date picker range variants.


**What is the current behavior?** <!--(You can also link to an open issue here)-->
Overlapping days in ranges spanning multiple months are not being highlight, making it unclear which date range has been selected. Example:
**Start date:** May 18, 2022
**End date:** June 8, 2022

After clicking June 8, the month of June properly highlights June 1st through June 8th, but does **not** indicate that May 29 through May 31 (the previous month where the starting date exists) are also part of the newly created range.
![Screen Shot 2022-05-13 at 9 50 00 AM](https://user-images.githubusercontent.com/94568316/168309517-7b636710-a7e5-4220-8137-d72f6c321bb3.png)

Additionally, after selecting the starting date, there is no styling to suggest what range would be created when hovering over a potential end date candidate. This can be confusing to a user who is not sure how the date range is actually being created based off their selections.

**What is the new behavior (if this is a feature change)?**

Highlights *all* days of a date range, regardless of if the days are in previous/future months in the currently displayed month/year UI, as well as the hypothetical range that would be created when hovering an end date:
![Screen Shot 2022-05-13 at 9 54 41 AM](https://user-images.githubusercontent.com/94568316/168310448-ce60bada-24a4-4cb6-91a9-c24bd5f755e0.png)

**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->

No

**Other information**:

Another alternative to this is to remove the days in the calendar that do not correspond with the following month being shown in the calendar UI. In the examples above, it would mean the slots for May 29 - May 31 would be empty.