### PR TITLE
doc: Update getting-started.mdx

### DIFF
--- a/framework/getting-started.mdx
+++ b/framework/getting-started.mdx
@@ -23,7 +23,13 @@ If your website has a content security policy, in order for the fonts to load an
 
 ## Sass Required
 
-The components import sass modules. The dart-sass (`sass` package) must be installed and integrated into your bundler.
+The components import sass modules. The dart-sass (`sass` package) must be installed and integrated into your bundler. Recommended to use `sass@1.43.3` or greater.
+
+```
+npm install --save-dev sass
+
+yarn add sass --dev
+```
 
 <br />
 


### PR DESCRIPTION
Clarify which `sass` package should be installed since there are various name changes and deprecations in the sass ecosystem.