### PR TITLE
feat: add singleton app ref

### DIFF
--- a/framework/components/ADialog/ADialog.js
+++ b/framework/components/ADialog/ADialog.js
@@ -36,7 +36,7 @@ const ADialog = forwardRef(
       }
     }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    const {appRef} = useContext(AAppContext);
+    const {appRef = window.__AAppMountEl} = useContext(AAppContext);
 
     const dialogRef = useRef(null);
     const combinedRef = useCombinedRefs(ref, dialogRef);

--- a/framework/components/AMount/AMount.js
+++ b/framework/components/AMount/AMount.js
@@ -22,6 +22,13 @@ const AMount = forwardRef(
     const {toasts, setToasts} = useContext(AAppContext);
     const [toasts2, setToasts2] = useState([]);
 
+    useLayoutEffect(() => {
+      if (!window.__AAppMountEl && combinedRef.current) {
+        window.__AAppMountEl = combinedRef;
+      }
+      return () => (window.__AAppMountEl = null);
+    });
+
     let className = "a-mount";
     if (propsClassName) {
       className += ` ${propsClassName}`;

--- a/framework/components/ASlider/ASlider.js
+++ b/framework/components/ASlider/ASlider.js
@@ -50,7 +50,7 @@ const ASlider = forwardRef(
     const sliderRef = useRef(null);
     const combinedRef = useCombinedRefs(ref, sliderRef);
     const [sliderId] = useState(sliderCounter++);
-    const {appRef} = useContext(AAppContext);
+    const {appRef = window.__AAppMountEl} = useContext(AAppContext);
     const [offset1, setOffset1] = useState(0);
     const [isDown1, setIsDown1] = useState(false);
     const [offset2, setOffset2] = useState(0);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [x] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [ ] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->


**What is the current behavior?** <!--(You can also link to an open issue here)-->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->



**Other information**:
The AAppContext is not able to be shared across different instances of AApp. With the move to micro-frontends, we will need to have the host app and remote micro-frontends define AApp separately (or not at all). Since AApp is traditionaly used only once on a page, we can add a `window` reference and fallback to that in the case that AApp is not defined in a remote micro-frontend.


