### PR TITLE
Fix pagination button group style

### DIFF
--- a/framework/components/APagination/APagination.scss
+++ b/framework/components/APagination/APagination.scss
@@ -26,6 +26,7 @@
 
   .a-button-group {
     margin: 0 5px;
+    width: auto;
 
     .a-button {
       padding: 0 7px;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] The commit message follows semantic commit message guidelines
- [ ] The changes are documented in component docs and changelog
- [ ] The ESLint plugin has been updated if a new component is added
- [ ] Test have been added or modified, if appropriate
- [x] Has been verified locally


**What kind of change does this PR introduce?** <!--(Bug fix, feature, docs update, ...)-->
<!--
  If this pull request is related to an issue, include:
  Closes #<issue_number>
  or
  Supports #<issue_number>
-->
Fix the pagination button group style.

**What is the current behavior?** <!--(You can also link to an open issue here)-->
The current pagination button group has style `width: 100%`, which caused undesired style in a flex container.
![Screen Shot 2022-09-21 at 12 49 00 AM](https://user-images.githubusercontent.com/1232684/191556268-8aa5c365-9b95-49f0-a731-83a085749967.png)


**What is the new behavior (if this is a feature change)?**
After updating the pagination button group style with `width: auto`, the style is fixed.
![Screen Shot 2022-09-21 at 12 48 11 AM](https://user-images.githubusercontent.com/1232684/191556438-8b1fcf92-9680-4c58-90cb-d185fb22ef20.png)


**Does this PR introduce a breaking change?** <!--(What changes might users need to make in their application due to this PR?)-->
No


**Other information**:


